### PR TITLE
[MM] Modify EHB point calculation with bracket thresholds

### DIFF
--- a/apps/web/app/api/check-auto-rank/route.ts
+++ b/apps/web/app/api/check-auto-rank/route.ts
@@ -130,7 +130,7 @@ export async function GET(request: NextRequest) {
       skillingBonusPoints,
       scaling,
     );
-    const ehbPoints = calculateEhbPoints(ehb, scaling);
+    const ehbPoints = calculateEhbPoints(ehb);
     const combatAchievementTierPoints = calculateCombatAchievementPoints(
       combatAchievementTier,
       scaling,

--- a/apps/web/app/rank-calculator/hooks/point-calculator/combat/use-ehb-points.ts
+++ b/apps/web/app/rank-calculator/hooks/point-calculator/combat/use-ehb-points.ts
@@ -1,11 +1,9 @@
 import { useWatch } from 'react-hook-form';
 import { RankCalculatorSchema } from '@/app/rank-calculator/[player]/submit-rank-calculator-validation';
 import { calculateEhbPoints } from '@/app/rank-calculator/utils/calculators/calculate-ehb-points';
-import { useCalculatorScaling } from '../use-calculator-scaling';
 
 export function useEhbPoints() {
   const ehb = useWatch<RankCalculatorSchema, 'ehb'>({ name: 'ehb' });
-  const scaling = useCalculatorScaling();
 
-  return calculateEhbPoints(ehb, scaling);
+  return calculateEhbPoints(ehb);
 }

--- a/apps/web/app/rank-calculator/utils/calculators/calculate-ehb-points.ts
+++ b/apps/web/app/rank-calculator/utils/calculators/calculate-ehb-points.ts
@@ -1,11 +1,9 @@
 import Decimal from 'decimal.js-light';
-
-
 /*
-0-500 is 1.5x
-501-1500 is 1.25x
-1500-2500 is 1x
-2500+ is .75
+  0-500 is 1.5x
+  501-1500 is 1.25x
+  1500-2500 is 1x
+  2500+ is .75
 */
 export function calculateEhbPoints(ehb: number) {
   const firstBracket = new Decimal(Math.min(ehb, 500)).times(1.5);

--- a/apps/web/app/rank-calculator/utils/calculators/calculate-ehb-points.ts
+++ b/apps/web/app/rank-calculator/utils/calculators/calculate-ehb-points.ts
@@ -1,10 +1,22 @@
 import Decimal from 'decimal.js-light';
 
-export function calculateEhbPoints(ehb: number, scaling: number) {
-  const pointsPerEhb = 1;
-  const scaledPoints = new Decimal(ehb)
-    .times(pointsPerEhb)
-    .times(scaling)
+
+/*
+0-500 is 1.5x
+501-1500 is 1.25x
+1500-2500 is 1x
+2500+ is .75
+*/
+export function calculateEhbPoints(ehb: number) {
+  const firstBracket = new Decimal(Math.min(ehb, 500)).times(1.5);
+  const secondBracket = new Decimal(Math.min(Math.max(ehb - 500, 0), 1000)).times(1.25);
+  const thirdBracket = new Decimal(Math.min(Math.max(ehb - 1500, 0), 1000)).times(1);
+  const fourthBracket = new Decimal(Math.max(ehb - 2500, 0)).times(0.75);
+
+  const scaledPoints = firstBracket
+    .plus(secondBracket)
+    .plus(thirdBracket)
+    .plus(fourthBracket)
     .toDecimalPlaces(0, Decimal.ROUND_FLOOR)
     .toNumber();
 


### PR DESCRIPTION
EHB points scale off the following heuristic:

0-500 is 1.5x
501-1500 is 1.25x
1500-2500 is 1x
2500+ is .75

I have removed the notion of join date scaling as well, as there was a vestigial scaling argument that was a constant return value of 1.