### PR TITLE
Add Mad Angel boss to the rank calculator

### DIFF
--- a/apps/web/app/rank-calculator/config/efficiency-rates.ts
+++ b/apps/web/app/rank-calculator/config/efficiency-rates.ts
@@ -108,6 +108,7 @@ export const ehbRates = {
   'Mithril dragon': 72, // Assuming an average of a 5 minute task consisting of 6 kills
   'Doom of Mokhaiotl': 18,
   'Maggot King': 33,
+  'Mad Angel': 60,
 } satisfies Record<string, number>;
 
 /**

--- a/apps/web/app/schemas/osrs.ts
+++ b/apps/web/app/schemas/osrs.ts
@@ -1795,6 +1795,8 @@ export const CollectionLogItemName = z.enum([
   'Elder venator fang',
   'Crimson kisten',
   'Maggot marquess',
+  'Hallowfell',
+  'Aggy',
 ]);
 
 export type CollectionLogItemName = z.infer<typeof CollectionLogItemName>;

--- a/apps/web/app/schemas/temple-api.ts
+++ b/apps/web/app/schemas/temple-api.ts
@@ -270,6 +270,7 @@ export const TempleOSRSCollectionLogCategory = z.enum([
   'miscellaneous',
   'doom_of_mokhaiotl',
   'maggot_king',
+  'the_mad_angel',
 ]);
 
 export type TempleOSRSCollectionLogCategory = z.infer<

--- a/apps/web/data/item-categories/mad-angel.ts
+++ b/apps/web/data/item-categories/mad-angel.ts
@@ -1,0 +1,23 @@
+import { formatWikiImageUrl } from '@/app/rank-calculator/utils/format-wiki-url';
+import { ItemCategory } from '@/app/schemas/items';
+import { singleItem } from '../utils/item-builders';
+
+export const madAngel: ItemCategory = {
+  image: formatWikiImageUrl('Mad Angel', 'category'),
+  items: [
+    singleItem({
+      name: 'Hallowfell',
+      // Native icon is smaller than the thumbnail size, so the /thumb/ URL
+      // 500s — use the full image directly.
+      image: 'https://oldschool.runescape.wiki/images/Hallowfell.png',
+      collectionLogCategory: 'the_mad_angel',
+      targetDropSources: ['Mad Angel'],
+    }),
+    singleItem({
+      name: 'Aggy',
+      image: 'https://oldschool.runescape.wiki/images/Aggy.png',
+      collectionLogCategory: 'the_mad_angel',
+      targetDropSources: ['Mad Angel'],
+    }),
+  ],
+};

--- a/apps/web/data/item-categories/maggot-king.ts
+++ b/apps/web/data/item-categories/maggot-king.ts
@@ -7,16 +7,21 @@ export const maggotKing: ItemCategory = {
   items: [
     singleItem({
       name: 'Elder venator fang',
+      // Native icon is smaller than the thumbnail size, so the /thumb/ URL
+      // 500s — use the full image directly.
+      image: 'https://oldschool.runescape.wiki/images/Elder_venator_fang.png',
       collectionLogCategory: 'maggot_king',
       targetDropSources: ['Maggot King'],
     }),
     singleItem({
       name: 'Crimson kisten',
+      image: 'https://oldschool.runescape.wiki/images/Crimson_kisten.png',
       collectionLogCategory: 'maggot_king',
       targetDropSources: ['Maggot King'],
     }),
     singleItem({
       name: 'Maggot marquess',
+      image: 'https://oldschool.runescape.wiki/images/Maggot_marquess.png',
       collectionLogCategory: 'maggot_king',
       targetDropSources: ['Maggot King'],
     }),

--- a/apps/web/data/item-list.ts
+++ b/apps/web/data/item-list.ts
@@ -25,6 +25,7 @@ import { kraken } from './item-categories/kraken';
 import { krearra } from './item-categories/krearra';
 import { maggotKing } from './item-categories/maggot-king';
 import { krilTsutsaroth } from './item-categories/kril-tsutsaroth';
+import { madAngel } from './item-categories/mad-angel';
 import { majorSlayerItems } from './item-categories/major-slayer-items';
 import { miscellaneous } from './item-categories/miscellaneous';
 import { miscellaneousWildernessItems } from './item-categories/miscellaneous-wilderness-items';
@@ -84,6 +85,7 @@ export const itemList: ItemCategoryMap = {
   "Kree'arra": krearra,
   "K'ril Tsutsaroth": krilTsutsaroth,
   'Maggot King': maggotKing,
+  'Mad Angel': madAngel,
   'Major Slayer Items': majorSlayerItems,
   'Miscellaneous Items': miscellaneous,
   'Miscellaneous Wilderness Items': miscellaneousWildernessItems,


### PR DESCRIPTION
Add the Mad Angel boss with its unique drop (Hallowfell, 1/127) and pet (Aggy, 1/2000). Points are computed dynamically from live wiki drop rates and the boss EHB (60), matching the yama/royal-titans pattern:
- register the Mad Angel item category and its two items
- add the Mad Angel EHB rate (60)
- add the Hallowfell/Aggy collection log item names and the the_mad_angel Temple category