### PR TITLE
Purge inactive players from the leaderboard

### DIFF
--- a/apps/web/app/data-sources/fetch-leaderboard.ts
+++ b/apps/web/app/data-sources/fetch-leaderboard.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db';
 import { playerAcquiredItems, players } from '@/lib/db/schema';
-import { desc, sql } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { AllPetItemIds } from '../schemas/osrs';
 
 export interface LeaderboardPlayer {
@@ -57,6 +57,8 @@ export async function fetchLeaderboard(
         playerAcquiredItems,
         sql`${players.playerName} = ${playerAcquiredItems.playerName} AND ${playerAcquiredItems.itemName} = 'Cursed phalanx'`,
       )
+      // Hide players soft-deleted by the daily inactivity reconcile.
+      .where(eq(players.isActive, true))
       .orderBy(desc(players.points))
       .limit(limit)
       .offset(offset);

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,8 +4,10 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Button, Flex } from '@radix-ui/themes';
 
+import { after } from 'next/server';
 import { auth, signIn } from '@/auth';
 import { redirect } from 'next/navigation';
+import { maybeRunInactivitySync } from '@/lib/db/inactivity-sync';
 import { fetchRecentRankUps } from './data-sources/fetch-recent-rank-ups';
 import { fetchRecentClogUpdates } from './data-sources/fetch-recent-clog-updates';
 import { fetchLeaderboard } from './data-sources/fetch-leaderboard';
@@ -26,6 +28,11 @@ const inter = Inter({
 });
 
 export default async function HomePage() {
+  // Kick off the daily inactivity reconcile (no server cron exists). Runs after
+  // the response is sent and self-throttles to once per 24h, so it never blocks
+  // or breaks the page.
+  after(maybeRunInactivitySync);
+
   // Check auth on page load and redirect if authed
   const session = await auth();
   const dashboardUrl = '/dashboard';

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,4 +1,10 @@
 import { defineConfig } from 'drizzle-kit';
+import { config } from 'dotenv';
+
+// drizzle-kit runs standalone from the CLI and does not load Next's .env.local
+// (Next only loads it at app runtime; jest.env.ts does the same for tests).
+// Load it here so DATABASE_URL is available for generate/migrate/push.
+config({ path: '.env.local' });
 
 export default defineConfig({
   schema: './lib/db/schema.ts',

--- a/apps/web/drizzle/0015_brown_imperial_guard.sql
+++ b/apps/web/drizzle/0015_brown_imperial_guard.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "sync_metadata" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"last_run_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "players" ADD COLUMN "is_active" boolean DEFAULT true NOT NULL;

--- a/apps/web/drizzle/meta/0015_snapshot.json
+++ b/apps/web/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,470 @@
+{
+  "id": "f6ad83de-e7ad-4aa1-8f8b-18ea5667607e",
+  "prevId": "e1b0fc35-2543-46ba-a619-7e3ab8ad85a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.player_achievement_diaries": {
+      "name": "player_achievement_diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_acquired_items": {
+      "name": "player_acquired_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_category": {
+          "name": "item_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_first_logged": {
+          "name": "date_first_logged",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_acquired_items_player_name_item_id_unique": {
+          "name": "player_acquired_items_player_name_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_rank_ups": {
+      "name": "player_rank_ups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "old_rank": {
+          "name": "old_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_rank": {
+          "name": "new_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ehb": {
+          "name": "ehb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ehp": {
+          "name": "ehp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_achievement_tier": {
+          "name": "combat_achievement_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_link": {
+          "name": "proof_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_log_count": {
+          "name": "collection_log_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_total": {
+          "name": "collection_log_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_level": {
+          "name": "total_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1154
+        },
+        "clue_count_beginner": {
+          "name": "clue_count_beginner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_easy": {
+          "name": "clue_count_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_medium": {
+          "name": "clue_count_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_hard": {
+          "name": "clue_count_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_elite": {
+          "name": "clue_count_elite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_master": {
+          "name": "clue_count_master",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tzhaar_cape": {
+          "name": "tzhaar_cape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "has_blood_torva": {
+          "name": "has_blood_torva",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_radiant_oathplate": {
+          "name": "has_radiant_oathplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dizanas_quiver": {
+          "name": "has_dizanas_quiver",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_achievement_diary_cape": {
+          "name": "has_achievement_diary_cape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "combat_bonus_points": {
+          "name": "combat_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skilling_bonus_points": {
+          "name": "skilling_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_bonus_points": {
+          "name": "collection_log_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notable_items_bonus_points": {
+          "name": "notable_items_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile_only": {
+          "name": "is_mobile_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_player_name_lower_unique": {
+          "name": "players_player_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"player_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1771712129206,
       "tag": "0014_neat_falcon",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1787047544162,
+      "tag": "0015_brown_imperial_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/inactivity-sync.ts
+++ b/apps/web/lib/db/inactivity-sync.ts
@@ -1,0 +1,141 @@
+import { differenceInDays } from 'date-fns';
+import { inArray } from 'drizzle-orm';
+import { sql } from 'drizzle-orm/sql/sql';
+import * as Sentry from '@sentry/nextjs';
+import { clientConstants } from '@/config/constants.client';
+import { serverConstants } from '@/config/constants.server';
+import { GroupMemberInfoResponse } from '@/app/schemas/temple-api';
+import { db } from './index';
+import { players, syncMetadata } from './schema';
+
+const INACTIVITY_SYNC_JOB_ID = 'inactivity-reconcile';
+
+// A player with no XP gain on TempleOSRS for longer than this is treated as
+// having left the clan and is hidden from the leaderboard (soft delete).
+export const INACTIVITY_THRESHOLD_DAYS = 90;
+
+/**
+ * OSRS display names can arrive with underscores, regular spaces or
+ * non-breaking spaces depending on the source. Normalise before comparing the
+ * Temple memberlist against our stored player names.
+ */
+function normaliseName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[\s_]+/g, ' ')
+    .trim();
+}
+
+async function fetchTempleMemberInfo(): Promise<GroupMemberInfoResponse> {
+  const response = await fetch(
+    `${clientConstants.temple.baseUrl}/api/group_member_info.php?id=${serverConstants.temple.groupId}`,
+  );
+
+  return GroupMemberInfoResponse.parse(await response.json());
+}
+
+type ReconcileResult =
+  | { skipped: true }
+  | { skipped: false; deactivated: number; reactivated: number };
+
+/**
+ * Reconciles the `is_active` flag on every stored player against TempleOSRS
+ * activity. This runs in both directions (self-healing):
+ *   - active players who are inactive beyond the threshold (or no longer in the
+ *     Temple group) are soft-deleted (`is_active = false`);
+ *   - previously soft-deleted players who have become active again are restored.
+ *
+ * If the Temple response is empty (API blip) the reconcile is skipped so we
+ * never mass-deactivate the whole leaderboard on bad data.
+ */
+export async function reconcileInactivePlayers(): Promise<ReconcileResult> {
+  const memberInfo = await fetchTempleMemberInfo();
+  const memberlist = Object.values(memberInfo.data.memberlist);
+
+  if (memberlist.length === 0) {
+    return { skipped: true };
+  }
+
+  // Normalised rsn -> days since last XP gain (Temple reports unix seconds).
+  const daysInactiveByPlayer = new Map<string, number>();
+  memberlist.forEach(({ player, last_changed_xp_unix_time: lastXpUnix }) => {
+    daysInactiveByPlayer.set(
+      normaliseName(player),
+      differenceInDays(Date.now(), lastXpUnix * 1000),
+    );
+  });
+
+  const storedPlayers = await db
+    .select({ playerName: players.playerName, isActive: players.isActive })
+    .from(players);
+
+  const toDeactivate: string[] = [];
+  const toReactivate: string[] = [];
+
+  storedPlayers.forEach(({ playerName, isActive }) => {
+    const daysInactive = daysInactiveByPlayer.get(normaliseName(playerName));
+
+    // Absent from the Temple group (left the clan) or inactive beyond the
+    // threshold => should be hidden. Present and recently active => visible.
+    const shouldBeInactive =
+      daysInactive === undefined ||
+      daysInactive > INACTIVITY_THRESHOLD_DAYS;
+
+    if (shouldBeInactive && isActive) {
+      toDeactivate.push(playerName);
+    } else if (!shouldBeInactive && !isActive) {
+      toReactivate.push(playerName);
+    }
+  });
+
+  if (toDeactivate.length > 0) {
+    await db
+      .update(players)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(inArray(players.playerName, toDeactivate));
+  }
+
+  if (toReactivate.length > 0) {
+    await db
+      .update(players)
+      .set({ isActive: true, updatedAt: new Date() })
+      .where(inArray(players.playerName, toReactivate));
+  }
+
+  return {
+    skipped: false,
+    deactivated: toDeactivate.length,
+    reactivated: toReactivate.length,
+  };
+}
+
+/**
+ * Runs the inactivity reconcile at most once per 24h. There is no server cron,
+ * so this is triggered by page traffic. The `sync_metadata` row is claimed
+ * atomically via an upsert whose update only fires when the last run was over
+ * 24h ago — so concurrent requests never double-run. Safe to call and forget
+ * (e.g. via `after()`); all errors are captured, never surfaced to the page.
+ */
+export async function maybeRunInactivitySync(): Promise<void> {
+  try {
+    const claimed = await db
+      .insert(syncMetadata)
+      .values({ id: INACTIVITY_SYNC_JOB_ID, lastRunAt: new Date() })
+      .onConflictDoUpdate({
+        target: syncMetadata.id,
+        set: { lastRunAt: new Date() },
+        setWhere: sql`${syncMetadata.lastRunAt} < now() - interval '24 hours'`,
+      })
+      .returning({ id: syncMetadata.id });
+
+    // Empty result => another request already claimed today's run, or the last
+    // run was under 24h ago.
+    if (claimed.length === 0) {
+      return;
+    }
+
+    await reconcileInactivePlayers();
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+}

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -75,6 +75,12 @@ export const players = pgTable(
     // Player preferences
     isMobileOnly: boolean('is_mobile_only').notNull().default(false),
 
+    // Soft-delete flag driven by the daily inactivity reconcile. Inactive
+    // players (no XP gain on TempleOSRS beyond the threshold, or no longer in
+    // the Temple group) are hidden from the leaderboard but their row is kept
+    // so they can be restored automatically if they become active again.
+    isActive: boolean('is_active').notNull().default(true),
+
     // Metadata
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -175,3 +181,14 @@ export const playerRankUpsRelations = relations(playerRankUps, ({ one }) => ({
     references: [players.playerName],
   }),
 }));
+
+// Singleton bookkeeping for scheduled-ish jobs that are triggered by page
+// traffic rather than a server cron (there is no long-running server). Each
+// job keeps one row keyed by a stable id and records when it last ran, so a
+// request can atomically "claim" a run and avoid duplicate work.
+export const syncMetadata = pgTable('sync_metadata', {
+  id: varchar('id', { length: 50 }).primaryKey(),
+  lastRunAt: timestamp('last_run_at').notNull().defaultNow(),
+});
+
+export type SyncMetadata = typeof syncMetadata.$inferSelect;


### PR DESCRIPTION
Adds a daily, traffic-triggered reconcile that hides players who have left the clan (or gone XP-idle) from the leaderboard, and restores them if they become active again — there is no server cron to run it.

- schema: add players.is_active (soft-delete flag) and a sync_metadata singleton table used to claim a run atomically (once per 24h) so concurrent requests never double-run.
- inactivity-sync: reconcileInactivePlayers() compares every stored player against the TempleOSRS group memberlist and flips is_active in both directions; deactivates players absent from the group or with no XP gain for >90 days; skips entirely on an empty Temple response so a bad API read can never mass-deactivate the board. maybeRunInactivitySync() does the 24h claim + run and swallows/report errors to Sentry.
- fetch-leaderboard: filter to is_active = true (single choke point for every leaderboard surface).
- page.tsx: kick off the reconcile via after() on the homepage, so it runs after the response and never blocks or breaks the page.
- drizzle.config: load .env.local via dotenv so DATABASE_URL is available for drizzle-kit CLI (generate/migrate/push).
- migration 0015: is_active column + sync_metadata table.