### PR TITLE
Stop a failed Discord lookup from zeroing diary bonus points

### DIFF
--- a/apps/web/app/api/update-all-players/route.ts
+++ b/apps/web/app/api/update-all-players/route.ts
@@ -36,6 +36,10 @@ export async function GET() {
     const results = [];
     let successCount = 0;
     let errorCount = 0;
+    // Players whose discord account is gone, and players we simply could not
+    // reach discord for — surfaced so a batch run never hides either silently.
+    const playersMissingFromDiscord: string[] = [];
+    const playersWithStaleDiscordRoles: string[] = [];
 
     // Process each player with rate limiting
     for (let i = 0; i < allPlayers.length; i++) {
@@ -58,10 +62,26 @@ export async function GET() {
 
         if (result.success) {
           successCount++;
+
+          const { discordMembership } = result.data;
+
+          if (discordMembership === 'not-a-member') {
+            playersMissingFromDiscord.push(player.playerName);
+          } else if (discordMembership === 'unavailable') {
+            playersWithStaleDiscordRoles.push(player.playerName);
+          }
+
           results.push({
             playerName: player.playerName,
             success: true,
             message: 'Updated successfully',
+            ...(discordMembership === 'not-a-member' && {
+              warning: `Discord user ${player.discordUserId} is no longer in the guild — diary bonus points have been cleared`,
+            }),
+            ...(discordMembership === 'unavailable' && {
+              warning:
+                'Could not reach discord — diary bonus points were carried over from the previous run',
+            }),
           });
         } else {
           errorCount++;
@@ -81,11 +101,25 @@ export async function GET() {
       }
     }
 
+    if (playersMissingFromDiscord.length > 0) {
+      console.warn(
+        `Players no longer in the discord guild: ${playersMissingFromDiscord.join(', ')}`,
+      );
+    }
+
+    if (playersWithStaleDiscordRoles.length > 0) {
+      console.warn(
+        `Discord roles could not be read for: ${playersWithStaleDiscordRoles.join(', ')}`,
+      );
+    }
+
     return NextResponse.json({
       success: true,
       message: `Batch update completed: ${successCount} successful, ${errorCount} failed`,
       playersUpdated: successCount,
       playersTotal: allPlayers.length,
+      playersMissingFromDiscord,
+      playersWithStaleDiscordRoles,
       results,
     });
   } catch (error) {

--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
@@ -28,7 +28,10 @@ import { fetchTemplePlayerCollectionLog } from './fetch-temple-collection-log';
 import { fetchTempleConstants } from './fetch-temple-constants';
 import { mergeTzhaarCapes } from './utils/merge-tzhaar-capes';
 import { isAchievementDiaryCapeAchieved } from '../../utils/is-achievement-diary-cape-achieved';
-import { fetchUserDiscordRoles } from '../fetch-user-discord-roles';
+import {
+  DiscordRolesResult,
+  fetchUserDiscordRoles,
+} from '../fetch-user-discord-roles';
 import { calculateCombatDiaryTierBonusPoints } from '../../utils/calculators/calculate-custom-diary-tier-multipliers';
 import { processPlayerData, getPlayerByName } from '@/lib/db/player-operations';
 import { TempleOSRSCollectionLogItem } from '@/app/schemas/temple-api';
@@ -43,6 +46,12 @@ export interface PlayerDetailsResponse
   isTempleCollectionLogOutdated: boolean;
   isMobileOnly: boolean;
   rawCollectionLogItems?: TempleOSRSCollectionLogItem[];
+  /**
+   * Whether we were able to read this player's discord roles. `unavailable`
+   * means the role-derived bonus points below are carried over from the stored
+   * record rather than freshly calculated.
+   */
+  discordMembership?: DiscordRolesResult['status'];
 }
 
 export const emptyResponse = {
@@ -301,8 +310,13 @@ export async function fetchPlayerDetails(
       ? isAchievementDiaryCapeAchieved(achievementDiaries)
       : false;
 
+    // A failed discord lookup is not evidence that the player holds no diary
+    // roles, so fall back to the stored values instead of zeroing them out.
     const { combatBonusPoints, collectionLogBonusPoints } =
-      calculateCombatDiaryTierBonusPoints(discordRoles);
+      calculateCombatDiaryTierBonusPoints(discordRoles) ?? {
+        combatBonusPoints: playerRecord.combatBonusPoints,
+        collectionLogBonusPoints: playerRecord.collectionLogBonusPoints,
+      };
 
     const result = {
       success: true as const,
@@ -351,6 +365,7 @@ export async function fetchPlayerDetails(
         hasThirdPartyData,
         isTempleCollectionLogOutdated,
         isMobileOnly: playerRecord.isMobileOnly ?? false,
+        discordMembership: discordRoles.status,
         collectionLogBonusPoints: collectionLogBonusPoints,
         combatBonusPoints,
         skillingBonusPoints: 0, // Leaving this in for future use, if we decide to add a skilling diary

--- a/apps/web/app/rank-calculator/data-sources/fetch-user-discord-roles.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-user-discord-roles.ts
@@ -1,26 +1,89 @@
 import { serverConstants } from '@/config/constants.server';
 import { discordBotClient } from '@/discord';
-import { APIGuildMember, Routes } from 'discord-api-types/v10';
+import { DiscordAPIError, HTTPError, RateLimitError } from '@discordjs/rest';
+import {
+  APIGuildMember,
+  RESTJSONErrorCodes,
+  Routes,
+} from 'discord-api-types/v10';
 import * as Sentry from '@sentry/nextjs';
 
-export async function fetchUserDiscordRoles(userId: string) {
-  try {
-    const {
-      discord: { guildId },
-    } = serverConstants;
+/**
+ * Three genuinely different outcomes, which callers must not collapse:
+ *
+ * - `ok`            — we know the member's roles.
+ * - `not-a-member`  — Discord is certain this user is not in the guild
+ *                     (left / kicked / banned, or a stale `discordUserId`).
+ *                     They really have lost their role-derived bonuses.
+ * - `unavailable`   — we could not find out (rate limit, outage, network).
+ *                     Says nothing about the member; callers must preserve
+ *                     whatever they already have rather than assume zero.
+ */
+export type DiscordRolesResult =
+  | { status: 'ok'; roles: Set<string> }
+  | { status: 'not-a-member' }
+  | { status: 'unavailable'; error: unknown };
 
+/**
+ * `@discordjs/rest` waits out 429s itself (`rejectOnRateLimit: null`) and
+ * retries 5xx/aborts (`retries: 3`), so rate limits are absorbed before they
+ * reach us. A `RateLimitError` only surfaces if that behaviour is ever
+ * reconfigured — classify it as transient rather than silently zeroing points.
+ */
+function isTransient(error: unknown) {
+  if (error instanceof RateLimitError || error instanceof HTTPError) {
+    return true;
+  }
+
+  if (error instanceof DiscordAPIError) {
+    return error.status === 429 || error.status >= 500;
+  }
+
+  // Network-level failures (fetch throws a TypeError) are transient too.
+  return true;
+}
+
+export async function fetchUserDiscordRoles(
+  userId: string,
+): Promise<DiscordRolesResult> {
+  const {
+    discord: { guildId },
+  } = serverConstants;
+
+  try {
     const { roles } = (await discordBotClient.get(
       Routes.guildMember(guildId, userId),
     )) as APIGuildMember;
 
-    return new Set(roles);
+    return { status: 'ok', roles: new Set(roles) };
   } catch (error) {
+    if (
+      error instanceof DiscordAPIError &&
+      error.code === RESTJSONErrorCodes.UnknownMember
+    ) {
+      // Expected, not exceptional — don't page Sentry for someone leaving.
+      console.warn(
+        `Discord user ${userId} is not a member of guild ${guildId}`,
+      );
+
+      return { status: 'not-a-member' };
+    }
+
+    if (isTransient(error)) {
+      console.warn(
+        `Temporarily unable to fetch discord roles for user: ${userId}`,
+        error,
+      );
+
+      return { status: 'unavailable', error };
+    }
+
     console.error(
       `Error while fetching discord roles for user: ${userId}`,
       error,
     );
     Sentry.captureException(error);
 
-    return null;
+    return { status: 'unavailable', error };
   }
 }

--- a/apps/web/app/rank-calculator/utils/calculators/calculate-custom-diary-tier-multipliers.spec.ts
+++ b/apps/web/app/rank-calculator/utils/calculators/calculate-custom-diary-tier-multipliers.spec.ts
@@ -1,27 +1,58 @@
 import { customDiaryDiscordRoles } from '@/config/discord-roles';
+import {
+  clogDiaryTierBonusPoints,
+  customDiaryTierBonusPoints,
+} from '@/config/custom-diaries';
 import { calculateCombatDiaryTierBonusPoints } from './calculate-custom-diary-tier-multipliers';
 
-it('calculates the correct tier multipliers', () => {
-  const roles = new Set<string>([customDiaryDiscordRoles.Combat.get('Easy')!]);
+function withRoles(...roles: string[]) {
+  return { status: 'ok' as const, roles: new Set(roles) };
+}
 
-  const { collectionLogBonusPoints, combatBonusPoints, skillingBonusPoints } =
-    calculateCombatDiaryTierBonusPoints(roles);
+it('calculates the correct tier bonus points', () => {
+  const result = calculateCombatDiaryTierBonusPoints(
+    withRoles(
+      customDiaryDiscordRoles.Combat.get('Easy')!,
+      customDiaryDiscordRoles.Clog.get('Elite')!,
+    ),
+  );
 
-  expect(collectionLogBonusPoints).toEqual(0.4);
-  expect(combatBonusPoints).toEqual(0.3);
-  expect(skillingBonusPoints).toEqual(0.1);
+  expect(result).toEqual({
+    combatBonusPoints: customDiaryTierBonusPoints.Easy,
+    collectionLogBonusPoints: clogDiaryTierBonusPoints.Elite,
+  });
 });
 
-it('calculates the correct tier multipliers when multiple roles for the same diary are present', () => {
-  const roles = new Set<string>([
-    customDiaryDiscordRoles.Combat.get('Easy')!,
-    customDiaryDiscordRoles.Combat.get('Hard')!,
-  ]);
+it('takes the highest tier when multiple roles for the same diary are present', () => {
+  const result = calculateCombatDiaryTierBonusPoints(
+    withRoles(
+      customDiaryDiscordRoles.Combat.get('Easy')!,
+      customDiaryDiscordRoles.Combat.get('Hard')!,
+    ),
+  );
 
-  const { collectionLogBonusPoints, combatBonusPoints, skillingBonusPoints } =
-    calculateCombatDiaryTierBonusPoints(roles);
+  expect(result).toEqual({
+    combatBonusPoints: customDiaryTierBonusPoints.Hard,
+    collectionLogBonusPoints: 0,
+  });
+});
 
-  expect(collectionLogBonusPoints).toEqual(0.4);
-  expect(combatBonusPoints).toEqual(0.4);
-  expect(skillingBonusPoints).toEqual(0.2);
+it('awards no bonus points when the user has left the guild', () => {
+  expect(
+    calculateCombatDiaryTierBonusPoints({ status: 'not-a-member' }),
+  ).toEqual({
+    combatBonusPoints: 0,
+    collectionLogBonusPoints: 0,
+  });
+});
+
+it('returns null when discord could not be reached, so the caller keeps its stored values', () => {
+  expect(
+    calculateCombatDiaryTierBonusPoints({
+      status: 'unavailable',
+      error: new Error('rate limited'),
+    }),
+  ).toBeNull();
+
+  expect(calculateCombatDiaryTierBonusPoints(null)).toBeNull();
 });

--- a/apps/web/app/rank-calculator/utils/calculators/calculate-custom-diary-tier-multipliers.ts
+++ b/apps/web/app/rank-calculator/utils/calculators/calculate-custom-diary-tier-multipliers.ts
@@ -3,22 +3,28 @@ import {
   clogDiaryTierBonusPoints,
   customDiaryTierBonusPoints,
 } from '@/config/custom-diaries';
+import { DiscordRolesResult } from '../../data-sources/fetch-user-discord-roles';
 
+/**
+ * `null` means "unknown" — the caller could not reach Discord and must keep
+ * whatever bonus points it already has, rather than persisting a zero that is
+ * indistinguishable from a member holding no diary roles.
+ */
 export function calculateCombatDiaryTierBonusPoints(
-  discordRoles: Set<string> | null,
+  discordRoles: DiscordRolesResult | null,
 ) {
-  if (!discordRoles) {
-    return {
-      combatBonusPoints: 0,
-      collectionLogBonusPoints: 0,
-    };
+  if (!discordRoles || discordRoles.status === 'unavailable') {
+    return null;
   }
+
+  const roles =
+    discordRoles.status === 'ok' ? discordRoles.roles : new Set<string>();
 
   // More readable imperative approach
   let combatBonusPoints = 0;
   const combatRoles = customDiaryDiscordRoles.Combat;
   for (const [tier, roleId] of combatRoles) {
-    if (discordRoles.has(roleId)) {
+    if (roles.has(roleId)) {
       combatBonusPoints = customDiaryTierBonusPoints[tier];
     }
   }
@@ -26,7 +32,7 @@ export function calculateCombatDiaryTierBonusPoints(
   let collectionLogBonusPoints = 0;
   const clogRoles = customDiaryDiscordRoles.Clog;
   for (const [tier, roleId] of clogRoles) {
-    if (discordRoles.has(roleId)) {
+    if (roles.has(roleId)) {
       collectionLogBonusPoints = clogDiaryTierBonusPoints[tier];
     }
   }


### PR DESCRIPTION
`fetchUserDiscordRoles` collapsed every failure into `null`, which `calculateCombatDiaryTierBonusPoints` then treated as "member holds no diary roles" and returned zeros for. Those zeros passed `updatePlayerWithFullData`'s `!== undefined` guards, so a batch run persisted them over the player's real bonuses — and `check-auto-rank` fed them into the point calc, lowering totals and the computed rank. A transient rate limit or outage did the same damage as leaving the guild.

Return a discriminated result instead:

- `not-a-member` (10007) — they really have lost the roles, so zeroing is correct, but warn rather than capture an expected event to Sentry.
- `unavailable` (429 / 5xx / network) — we learned nothing, so carry the stored bonus points over instead of assuming zero. Note that @discordjs/rest already waits out 429s (`rejectOnRateLimit: null`) and retries 5xx, so this branch is a backstop.
- anything else (401/403 etc.) — still a real bug, still Sentry.

`update-all-players` now reports both cases per player and in the summary, so a departed member is visible rather than a stray stack trace in the logs.

Also refreshes the spec, which was stale and failing: it asserted 0.4/0.3/0.1 and a `skillingBonusPoints` field the function has never returned (bonuses are 500/1000/2000/4000).