### PR TITLE
Stack the notable-item category title over its count

### DIFF
--- a/apps/web/app/rank-calculator/components/rank-calculator.module.css
+++ b/apps/web/app/rank-calculator/components/rank-calculator.module.css
@@ -707,17 +707,26 @@
   border-radius: 6px;
 }
 
+/* Title over count. Both are spans, so without an explicit column the two run
+   together inline ("Abyssal Sire0 / 5") and the count's margin is dropped. */
 .categoryIdentity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   flex: 1;
   min-width: 0;
 }
 
 .categoryTitle {
+  max-width: 100%;
   font-size: 0.9375rem;
   font-weight: 500;
   color: rgb(var(--ig-text));
   margin: 0;
   line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .categoryCount {


### PR DESCRIPTION
The `x / x` count in the notable-item list's boss-drop headers had no spacing from the boss name — it rendered flush inline, e.g. `Abyssal Sire0 / 5`.

## Cause

`.categoryIdentity` was a plain block, and both of its children are `<span>`s:

```jsx
<span className={styles.categoryTitle}>{title}</span>
<span className={styles.categoryCount}>{`${completedCount} / ${items.length}`}</span>
```

JSX strips whitespace containing a newline between sibling elements, so the two inline boxes sat directly against each other. `.categoryCount`'s `margin-top: 0.15rem` was silently dropped too, since vertical margins don't apply to inline boxes.

The CSS was already written for a stacked two-line identity (that `margin-top`, plus `line-height: 1.2` on the title) — it just never got the column to sit in.

## Fix

- `.categoryIdentity` becomes a `flex-direction: column` container, so the count drops beneath the title with the spacing already specified.
- `.categoryTitle` gets `max-width: 100%` and ellipsis truncation; `min-width: 0` was on the container for long boss names, but nothing consumed it.

CSS only — no markup change, so every `aria-label` the Jest and Cypress suites query is untouched.

## Testing

- `yarn test item-list` passes (4/4); prettier clean.
- Checked the other span pairs in `panel.tsx` for the same mistake — `.tileHead` is a grid and `.panelMeterMeta` is a flex row, so the category header was the only place it bit.
- **Not visually verified**: the calculator is auth-gated, so there's no headless way to render it. Worth a quick look in the browser before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)