### PR TITLE
Category header layout fix + document the ship-it workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,20 @@ Adding a new boss/drop is a well-defined workflow — use the `add-osrs-content`
 - **`apps/web/jest.env.ts` is required** by `jest.config.ts` (setupFiles) but is untracked/absent on fresh checkouts — Jest won't start without it. It loads `.env.local` via dotenv (Next skips `.env.local` when `NODE_ENV=test`, hence the manual load).
 - Server config (`config/constants.server.ts`) parses many env vars at import; `mocks/handlers.ts` imports it, so tests need those vars present in `.env.local`.
 
+## Shipping a change
+
+When the work is done, don't stop at the working tree — branch, push, open a PR, and put it on screen:
+
+```sh
+git checkout -b mm/<short-slug> origin/main   # never commit straight to main
+git commit -am "<summary>"
+git push -u origin HEAD
+gh pr create --base main --title "<title>" --body "<what changed, why, how it was tested>"
+open "$(gh pr view --json url --jq .url)"     # macOS: opens the PR in the default browser
+```
+
+`gh` is installed via Homebrew and authenticated as `mattlm0831`. The PR body should say what was **not** verified as well as what was — e.g. anything behind the Discord auth gate can't be checked headlessly.
+
 ## Drift canary
 `app/rank-calculator/utils/notable-item-points-drift.spec.ts` hits the **live wiki** and lists every notable item that currently renders `-`. Run it to see what's broken after wiki drift. (Networked — not a hermetic unit test.) `schemas/wiki.spec.ts` is the hermetic guard for the casing normalisation.
 

--- a/apps/web/app/rank-calculator/components/rank-calculator.module.css
+++ b/apps/web/app/rank-calculator/components/rank-calculator.module.css
@@ -707,17 +707,26 @@
   border-radius: 6px;
 }
 
+/* Title over count. Both are spans, so without an explicit column the two run
+   together inline ("Abyssal Sire0 / 5") and the count's margin is dropped. */
 .categoryIdentity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   flex: 1;
   min-width: 0;
 }
 
 .categoryTitle {
+  max-width: 100%;
   font-size: 0.9375rem;
   font-weight: 500;
   color: rgb(var(--ig-text));
   margin: 0;
   line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .categoryCount {


### PR DESCRIPTION
Two changes.

## 1. Stack the notable-item category title over its count

The `x / x` count in the boss-drop headers had no spacing from the boss name — it rendered flush inline, e.g. `Abyssal Sire0 / 5`.

`.categoryIdentity` was a plain block and both of its children are `<span>`s:

```jsx
<span className={styles.categoryTitle}>{title}</span>
<span className={styles.categoryCount}>{`${completedCount} / ${items.length}`}</span>
```

JSX strips whitespace containing a newline between sibling elements, so the two inline boxes sat directly against each other. `.categoryCount`'s `margin-top: 0.15rem` was silently dropped too, since vertical margins don't apply to inline boxes. The CSS was already written for a stacked two-line identity (that `margin-top`, plus `line-height: 1.2` on the title) — it just never got the column to sit in.

- `.categoryIdentity` becomes a `flex-direction: column` container, so the count drops beneath the title with the spacing already specified.
- `.categoryTitle` gets `max-width: 100%` and ellipsis truncation; `min-width: 0` was on the container for long boss names, but nothing consumed it.

CSS only — no markup change, so every `aria-label` the Jest and Cypress suites query is untouched.

**Testing:** `yarn test item-list` passes (4/4); prettier clean. Checked the other span pairs in `panel.tsx` for the same mistake — `.tileHead` is a grid and `.panelMeterMeta` is a flex row, so the category header was the only place it bit. **Not visually verified**: the calculator is auth-gated, so there's no headless way to render it — worth a look in the browser before merging.

## 2. Document the ship-it workflow

Adds a **Shipping a change** section to `CLAUDE.md`: finished work doesn't stop at the working tree — branch off `origin/main`, push, open a PR, and open that PR in the default browser. Includes the exact commands, notes that `gh` is installed and authenticated, and asks that PR bodies state what was *not* verified.

Supersedes #75, which carried the CSS fix on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)