### PR TITLE
Drop the item-count badge from the collection log feed

### DIFF
--- a/apps/web/app/components/activity-feed.module.css
+++ b/apps/web/app/components/activity-feed.module.css
@@ -97,7 +97,7 @@
   color: rgb(var(--ig-text-muted) / 0.5);
 }
 
-/* Trailing metadata (time + count) */
+/* Trailing metadata */
 .trailing {
   flex-shrink: 0;
   display: flex;
@@ -110,15 +110,6 @@
   font-size: 11px;
   color: rgb(var(--ig-text-muted));
   white-space: nowrap;
-}
-.count {
-  font-family: var(--font-mono), ui-monospace, monospace;
-  font-size: 11px;
-  font-weight: 600;
-  color: rgb(var(--ig-secondary));
-  background: rgb(var(--ig-secondary) / 0.12);
-  border-radius: 999px;
-  padding: 0.05rem 0.4rem;
 }
 
 /* Rank-up "old -> new" */

--- a/apps/web/app/components/recent-clog-updates-table.tsx
+++ b/apps/web/app/components/recent-clog-updates-table.tsx
@@ -12,7 +12,6 @@ interface ClogUpdateData {
   playerName: string;
   itemName: string;
   itemId: number;
-  count: number;
   dateFirstLogged: Date;
 }
 
@@ -73,9 +72,6 @@ export function RecentClogUpdatesTable({
               <span className={styles.time}>
                 {formatTimeAgo(update.dateFirstLogged)}
               </span>
-              {update.count > 1 && (
-                <span className={styles.count}>&times;{update.count}</span>
-              )}
             </div>
           </div>
         ))}

--- a/apps/web/app/data-sources/fetch-recent-clog-updates.ts
+++ b/apps/web/app/data-sources/fetch-recent-clog-updates.ts
@@ -10,7 +10,6 @@ export async function fetchRecentClogUpdates() {
         playerName: playerAcquiredItems.playerName,
         itemName: playerAcquiredItems.itemName,
         itemId: playerAcquiredItems.itemId,
-        count: playerAcquiredItems.count,
         dateFirstLogged: playerAcquiredItems.dateFirstLogged,
       })
       .from(playerAcquiredItems)


### PR DESCRIPTION
## What

Removes the `×2` / `×4` badge under the time-ago in the Collection Log activity feed (homepage + dashboard).

The number was `player_acquired_items.count` — the player's **total logged quantity** of that item, synced from TempleOSRS. It doesn't describe the drop that just landed, and it sat beside a timestamp taken from `dateFirstLogged`, i.e. the *first* time they logged the item, so the badge and the time weren't even describing the same event. It didn't earn its place in the feed.

Cleaned up the whole path rather than just hiding it:

- `recent-clog-updates-table.tsx` — badge JSX and `count` off the `ClogUpdateData` interface
- `fetch-recent-clog-updates.ts` — `count` dropped from the select (this data source has no other consumer)
- `activity-feed.module.css` — the `.count` style, now unused by both feeds that share this module

`.trailing` stays: the rank-ups feed uses it too, and the time still needs its right-aligned column.

## Testing

- `npx eslint` on both changed TS files — clean.
- No test references the badge (nothing else read `styles.count` or the `count` field).
- **Not verified:** the rendered feed. Repo-wide `tsc --noEmit` doesn't run here (the composite project config errors out with TS6305 before typechecking, pre-existing), so type coverage on this change comes from eslint's type-aware rules rather than a full build.