### PR TITLE
Add an accomplishments feed alongside rank ups and clogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,36 @@ Three things to preserve when touching this page:
 
 Data-source convention: return `{ success: true, data } | { success: false, error }`; filter to `players.isActive`; `isMaxed = totalLevel === 2376`; pets = `playerAcquiredItems.itemId in AllPetItemIds`; infernal = `tzhaarCape === 'Infernal cape'`.
 
+## Accomplishments feed
+
+The third activity feed, alongside rank ups and collection log — the notable things a member does that are not a promotion and not a single drop. It runs **full width above** the other two on both the homepage and the dashboard.
+
+`player_accomplishments` (migration `0019`) is one row per thing achieved. Four files, one job each:
+
+| | |
+|---|---|
+| `app/schemas/accomplishments.ts` | the `AccomplishmentType` enum (mirrors `accomplishmentTypeEnum`), plus its labels and **wiki-image icons** |
+| `config/accomplishments.ts` | the numbers — `milestoneThresholds`, which CA tiers count, the feed size |
+| `app/utils/detect-accomplishments.ts` | pure: a snapshot in, the accomplishments it qualifies for out |
+| `lib/db/accomplishment-operations.ts` | `syncPlayerAccomplishments` — loads the snapshot, writes what's new |
+
+**Detection is stateless, and that is the whole design.** `detectAccomplishments` reports everything a player *currently* qualifies for — never "what changed" — and every row is inserted `on conflict do nothing` against `(player_name, accomplishment_key)`. Nothing has to diff against the last run, so re-running is free and a **missed run is caught up rather than lost**. Two consequences to keep in mind:
+
+- **`accomplishment_key` is the identity and must stay stable.** Never build it from a label or a live count. Renaming a key re-announces the accomplishment to everyone.
+- **Lowering a threshold in `milestoneThresholds` retroactively announces it** for everyone already past it. Raising or removing one is safe. Treat the list as append-only in practice.
+
+A player crossing several thresholds at once earns **all** of them (1,100 clog slots → 100/250/500/750/1000), and Grandmaster CAs earn Master too. That is deliberate and follows from statelessness.
+
+⚠️ **The first pass over a player is backfill.** Members join with a whole account behind them, so the first detection would otherwise dump a decade of history into the feed at once. `players.accomplishments_backfilled_at` marks that a player has had their first pass; everything found in it is written with `is_backfilled = true` and **`fetch-recent-accomplishments` filters those out**. The timestamp is set even when nothing was detected — otherwise a brand-new account would stay in backfill mode forever and its first real accomplishment would be swallowed.
+
+**When it runs.** `processPlayerData` calls it after the player record is written (it reads that record, not a live API), so the batch `GET /api/update-all-players` and every calculator save both cover it — no new endpoint. The call is wrapped in its own try/catch: a member's stats landing is the point, and noticing what they add up to can wait for the next run.
+
+**Icons come from the type**, resolved as OSRS Wiki image names through `formatWikiImageUrl` exactly like clog items (`ItemImageWithFallback` degrades to an avatar if the wiki renames one). The one exception is `icon_item_name`, which a row sets when the accomplishment names its own item — a pet is its own picture.
+
+**Accomplishments follow the player.** `deletePlayer` deletes them and the rename path in `edit-player-action.ts` moves them; miss the rename and the next pass treats the player as brand new and re-earns the lot.
+
+Mains are included — this is not the ladder. There is **no EHC milestone**: nothing stores efficient-hours-collected per player (`petEhcRates` is points config, not a player stat), so there is no data to detect it from.
+
 ## Favicon / app icons (App Router gotcha)
 
 Icons come from **file conventions**, not `metadata.icons`: `app/favicon.ico`, `app/icon.png`, `app/apple-icon.png` (all generated from `public/L1.png`). These files **take precedence over any `icons` field in `layout.tsx` metadata** — if the favicon is wrong, it's because a stale `app/favicon.ico` exists, not the metadata. To change icons, replace those files (regenerate from the logo with `sharp`); don't add `metadata.icons`.

--- a/apps/web/app/components/item-image-with-fallback.tsx
+++ b/apps/web/app/components/item-image-with-fallback.tsx
@@ -6,7 +6,12 @@ import { Avatar } from '@radix-ui/themes';
 import { formatWikiImageUrl } from '@/app/rank-calculator/utils/format-wiki-url';
 
 interface ItemImageWithFallbackProps {
-  itemId: number;
+  /**
+   * Unused — the wiki image is resolved from the name. Kept because callers
+   * have one to hand, and optional because callers rendering something that is
+   * not a collection-log item (an accomplishment icon) do not.
+   */
+  itemId?: number;
   itemName: string;
   size?: number;
   style?: React.CSSProperties;

--- a/apps/web/app/components/recent-accomplishments-table.tsx
+++ b/apps/web/app/components/recent-accomplishments-table.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { StarIcon } from '@radix-ui/react-icons';
+import { formatTimeAgo } from '@/app/utils/format-time-ago';
+import {
+  AccomplishmentType,
+  accomplishmentTypeIcons,
+  accomplishmentTypeLabels,
+} from '@/app/schemas/accomplishments';
+import { ItemImageWithFallback } from './item-image-with-fallback';
+import { SectionHeader } from './section-header';
+import { PlayerNameButton } from './player-name-button';
+import styles from './activity-feed.module.css';
+
+interface AccomplishmentData {
+  id: string;
+  playerName: string;
+  type: AccomplishmentType;
+  label: string;
+  iconItemName: string | null;
+  achievedAt: Date;
+}
+
+interface RecentAccomplishmentsProps {
+  accomplishments: AccomplishmentData[];
+}
+
+export function RecentAccomplishmentsTable({
+  accomplishments,
+}: RecentAccomplishmentsProps) {
+  const header = (
+    <div className={styles.header}>
+      <SectionHeader
+        title="Accomplishments"
+        subtitle="Milestones and feats across the clan"
+        icon={<StarIcon width={18} height={18} />}
+      />
+    </div>
+  );
+
+  if (accomplishments.length === 0) {
+    return (
+      <div className={styles.card}>
+        {header}
+        <div className={styles.empty}>
+          No recent accomplishments
+          <span className={styles.emptyHint}>
+            Milestones appear here as members reach them
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.card}>
+      {header}
+      <div className={styles.list}>
+        {accomplishments.map((accomplishment) => {
+          // A pet is its own picture; everything else is identified by its type.
+          const iconName =
+            accomplishment.iconItemName ??
+            accomplishmentTypeIcons[accomplishment.type];
+
+          return (
+            <div key={accomplishment.id} className={styles.row}>
+              <div className={styles.tile}>
+                <ItemImageWithFallback itemName={iconName} size={30} />
+              </div>
+              <div className={styles.body}>
+                <span className={styles.title}>{accomplishment.label}</span>
+                <span className={styles.meta}>
+                  <PlayerNameButton
+                    name={accomplishment.playerName}
+                    className={styles.player}
+                  />
+                  <span className={styles.dot}>·</span>
+                  {accomplishmentTypeLabels[accomplishment.type]}
+                </span>
+              </div>
+              <div className={styles.trailing}>
+                <span className={styles.time}>
+                  {formatTimeAgo(accomplishment.achievedAt)}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/recent-accomplishments-table.tsx
+++ b/apps/web/app/components/recent-accomplishments-table.tsx
@@ -38,18 +38,13 @@ export function RecentAccomplishmentsTable({
     </div>
   );
 
+  // Renders nothing rather than an empty-state card — this feed starts empty
+  // by design (a player's first detection pass is backfill and stays out of
+  // it), so a "nothing has happened yet" card would be the homepage's
+  // headline for weeks after launch. Callers already guard on length to avoid
+  // leaving a gap in their flex layout; this is the backstop.
   if (accomplishments.length === 0) {
-    return (
-      <div className={styles.card}>
-        {header}
-        <div className={styles.empty}>
-          No recent accomplishments
-          <span className={styles.emptyHint}>
-            Milestones appear here as members reach them
-          </span>
-        </div>
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -3,11 +3,13 @@ import { redirect } from 'next/navigation';
 import { Inter } from 'next/font/google';
 import { fetchRecentRankUps } from '@/app/data-sources/fetch-recent-rank-ups';
 import { fetchRecentClogUpdates } from '@/app/data-sources/fetch-recent-clog-updates';
+import { fetchRecentAccomplishments } from '@/app/data-sources/fetch-recent-accomplishments';
 import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
 import { fetchUserRecentClogs } from '@/app/data-sources/fetch-user-recent-clogs';
 import { fetchLeaderboard } from '@/app/data-sources/fetch-leaderboard';
 import { RecentRankUpsTable } from '@/app/components/recent-rank-ups-table';
 import { RecentClogUpdatesTable } from '@/app/components/recent-clog-updates-table';
+import { RecentAccomplishmentsTable } from '@/app/components/recent-accomplishments-table';
 import { RecentClogsContainer } from '@/app/components/recent-clogs-container';
 import { Leaderboard } from '@/app/components/leaderboard';
 import { NavBar } from '@/app/components/nav-bar';
@@ -34,6 +36,11 @@ export default async function DashboardPage() {
   const recentClogUpdatesResult = await fetchRecentClogUpdates();
   const recentClogUpdates = recentClogUpdatesResult.success
     ? recentClogUpdatesResult.data
+    : [];
+
+  const recentAccomplishmentsResult = await fetchRecentAccomplishments();
+  const recentAccomplishments = recentAccomplishmentsResult.success
+    ? recentAccomplishmentsResult.data
     : [];
 
   // Fetch user's calculators
@@ -148,8 +155,22 @@ export default async function DashboardPage() {
                 margin: 0,
               }}
             >
-              Recent member promotions and collection log updates
+              Recent accomplishments, member promotions and collection log
+              updates
             </p>
+          </div>
+
+          {/* Accomplishments — the headline feed, full width above the
+              narrower rank-up and collection-log columns */}
+          <div
+            style={{
+              maxWidth: '1200px',
+              margin: '0 auto 2rem',
+            }}
+          >
+            <RecentAccomplishmentsTable
+              accomplishments={recentAccomplishments ?? []}
+            />
           </div>
 
           <div

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
 
   const recentAccomplishmentsResult = await fetchRecentAccomplishments();
   const recentAccomplishments = recentAccomplishmentsResult.success
-    ? recentAccomplishmentsResult.data
+    ? (recentAccomplishmentsResult.data ?? [])
     : [];
 
   // Fetch user's calculators
@@ -155,23 +155,27 @@ export default async function DashboardPage() {
                 margin: 0,
               }}
             >
-              Recent accomplishments, member promotions and collection log
-              updates
+              {recentAccomplishments.length > 0
+                ? 'Recent accomplishments, member promotions and collection log updates'
+                : 'Recent member promotions and collection log updates'}
             </p>
           </div>
 
           {/* Accomplishments — the headline feed, full width above the
-              narrower rank-up and collection-log columns */}
-          <div
-            style={{
-              maxWidth: '1200px',
-              margin: '0 auto 2rem',
-            }}
-          >
-            <RecentAccomplishmentsTable
-              accomplishments={recentAccomplishments ?? []}
-            />
-          </div>
+              narrower rank-up and collection-log columns. Hidden entirely
+              until there is something to show; see the note on the homepage. */}
+          {recentAccomplishments.length > 0 && (
+            <div
+              style={{
+                maxWidth: '1200px',
+                margin: '0 auto 2rem',
+              }}
+            >
+              <RecentAccomplishmentsTable
+                accomplishments={recentAccomplishments}
+              />
+            </div>
+          )}
 
           <div
             style={{

--- a/apps/web/app/data-sources/fetch-recent-accomplishments.ts
+++ b/apps/web/app/data-sources/fetch-recent-accomplishments.ts
@@ -1,0 +1,57 @@
+import { db } from '@/lib/db';
+import { playerAccomplishments, players } from '@/lib/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+import { accomplishmentFeedSize } from '@/config/accomplishments';
+
+export interface RecentAccomplishment {
+  id: string;
+  playerName: string;
+  type: (typeof playerAccomplishments.$inferSelect)['type'];
+  label: string;
+  iconItemName: string | null;
+  achievedAt: Date;
+}
+
+/**
+ * The clan's latest accomplishments, newest first.
+ *
+ * Backfilled rows are excluded: they are real accomplishments, but they were
+ * found in a player's first detection pass and we have no idea when they
+ * happened, so they are not news. Mains are included — they are members, and
+ * this is not the ladder.
+ */
+export async function fetchRecentAccomplishments(
+  limit = accomplishmentFeedSize,
+) {
+  try {
+    const recentAccomplishments = await db
+      .select({
+        id: playerAccomplishments.id,
+        playerName: playerAccomplishments.playerName,
+        type: playerAccomplishments.type,
+        label: playerAccomplishments.label,
+        iconItemName: playerAccomplishments.iconItemName,
+        achievedAt: playerAccomplishments.achievedAt,
+      })
+      .from(playerAccomplishments)
+      .innerJoin(
+        players,
+        eq(players.playerName, playerAccomplishments.playerName),
+      )
+      .where(
+        and(
+          // Still in the clan...
+          eq(players.isActive, true),
+          // ...and not something we merely noticed on their first pass.
+          eq(playerAccomplishments.isBackfilled, false),
+        ),
+      )
+      .orderBy(desc(playerAccomplishments.achievedAt))
+      .limit(limit);
+
+    return { success: true, data: recentAccomplishments };
+  } catch (error) {
+    console.error('Failed to fetch recent accomplishments:', error);
+    return { success: false, error: String(error) };
+  }
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import { redirect } from 'next/navigation';
 import { maybeRunInactivitySync } from '@/lib/db/inactivity-sync';
 import { fetchRecentRankUps } from './data-sources/fetch-recent-rank-ups';
 import { fetchRecentClogUpdates } from './data-sources/fetch-recent-clog-updates';
+import { fetchRecentAccomplishments } from './data-sources/fetch-recent-accomplishments';
 import { fetchLeaderboard } from './data-sources/fetch-leaderboard';
 import { fetchClanStats } from './data-sources/fetch-clan-stats';
 import { fetchCollectionLogInsights } from './data-sources/fetch-collection-log-insights';
@@ -17,6 +18,7 @@ import { ClanStats } from './components/clan-stats';
 import { RarestDrops } from './components/rarest-drops';
 import { RecentRankUpsTable } from './components/recent-rank-ups-table';
 import { RecentClogUpdatesTable } from './components/recent-clog-updates-table';
+import { RecentAccomplishmentsTable } from './components/recent-accomplishments-table';
 import { Leaderboard } from './components/leaderboard';
 import { FadeInOnScroll } from './components/fade-in-on-scroll';
 
@@ -48,6 +50,11 @@ export default async function HomePage() {
   const recentClogUpdatesResult = await fetchRecentClogUpdates();
   const recentClogUpdates = recentClogUpdatesResult.success
     ? recentClogUpdatesResult.data
+    : [];
+
+  const recentAccomplishmentsResult = await fetchRecentAccomplishments();
+  const recentAccomplishments = recentAccomplishmentsResult.success
+    ? recentAccomplishmentsResult.data
     : [];
 
   // Fetch leaderboard data (fetch more to account for unranked players being filtered)
@@ -195,6 +202,14 @@ export default async function HomePage() {
                 }}
               >
                 <Leaderboard initialPlayers={leaderboard} />
+              </div>
+
+              {/* Accomplishments — the headline feed, full width above the
+                  narrower rank-up and collection-log columns */}
+              <div style={{ width: '100%', maxWidth: '1250px' }}>
+                <RecentAccomplishmentsTable
+                  accomplishments={recentAccomplishments ?? []}
+                />
               </div>
 
               {/* Recent activity tables */}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -54,7 +54,7 @@ export default async function HomePage() {
 
   const recentAccomplishmentsResult = await fetchRecentAccomplishments();
   const recentAccomplishments = recentAccomplishmentsResult.success
-    ? recentAccomplishmentsResult.data
+    ? (recentAccomplishmentsResult.data ?? [])
     : [];
 
   // Fetch leaderboard data (fetch more to account for unranked players being filtered)
@@ -205,12 +205,23 @@ export default async function HomePage() {
               </div>
 
               {/* Accomplishments — the headline feed, full width above the
-                  narrower rank-up and collection-log columns */}
-              <div style={{ width: '100%', maxWidth: '1250px' }}>
-                <RecentAccomplishmentsTable
-                  accomplishments={recentAccomplishments ?? []}
-                />
-              </div>
+                  narrower rank-up and collection-log columns.
+
+                  Hidden entirely until there is something to show. Unlike the
+                  other two feeds this one starts empty by design: a player's
+                  first detection pass is recorded as backfill and kept out of
+                  the feed, so an empty-state card would sit on the homepage
+                  for weeks after launch announcing that nothing has happened.
+                  Guarded here rather than inside the component because the
+                  parent is a flex column with a gap — an element that renders
+                  nothing still leaves a hole. */}
+              {recentAccomplishments.length > 0 && (
+                <div style={{ width: '100%', maxWidth: '1250px' }}>
+                  <RecentAccomplishmentsTable
+                    accomplishments={recentAccomplishments}
+                  />
+                </div>
+              )}
 
               {/* Recent activity tables */}
               <div

--- a/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
+++ b/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
@@ -17,6 +17,7 @@ import {
   playerAcquiredItems,
   playerAchievementDiaries,
   playerRankUps,
+  playerAccomplishments,
 } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
@@ -102,6 +103,14 @@ export const editPlayerAction = authActionClient
             .update(playerRankUps)
             .set({ playerName: maybeFormattedPlayerName })
             .where(eq(playerRankUps.playerName, previousPlayerName));
+
+          // Accomplishments move with the player. Missing this would strand
+          // them under the old name, and the next detection pass would treat
+          // the renamed player as brand new and re-earn the lot.
+          await tx
+            .update(playerAccomplishments)
+            .set({ playerName: maybeFormattedPlayerName })
+            .where(eq(playerAccomplishments.playerName, previousPlayerName));
         });
       } else {
         // No name change, just update the player record

--- a/apps/web/app/schemas/accomplishments.ts
+++ b/apps/web/app/schemas/accomplishments.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+
+/**
+ * The kind of accomplishment. Mirrors `accomplishmentTypeEnum` in
+ * `lib/db/schema.ts` for the app layer, the same way `StaffRole` mirrors
+ * `staffRoleEnum`.
+ *
+ * The type is the *whole* presentation decision: it picks the icon and the
+ * wording of the feed row's second line. Detection — when a thing is earned —
+ * lives in `app/utils/detect-accomplishments.ts`, and the numbers it compares
+ * against live in `config/accomplishments.ts`. Adding a new accomplishment
+ * means adding a value here, an icon below, and a rule there.
+ */
+export const AccomplishmentType = z.enum([
+  'collection_log',
+  'total_level',
+  'ehb',
+  'ehp',
+  'maxed',
+  'elite_diary',
+  'diary_cape',
+  'combat_achievement',
+  'inferno',
+  'colosseum',
+  'blood_torva',
+  'radiant_oathplate',
+  'toa_cursed_phalanx',
+  'pet',
+]);
+
+export type AccomplishmentType = z.infer<typeof AccomplishmentType>;
+
+/**
+ * The accomplishments a player earns repeatedly, once per threshold crossed.
+ * Everything else is a one-off feat, earned exactly once.
+ */
+export const MilestoneAccomplishmentType = AccomplishmentType.extract([
+  'collection_log',
+  'total_level',
+  'ehb',
+  'ehp',
+]);
+
+export type MilestoneAccomplishmentType = z.infer<
+  typeof MilestoneAccomplishmentType
+>;
+
+/**
+ * The category shown above the accomplishment in the feed — what *kind* of
+ * thing this is, where the stored label says which one.
+ */
+export const accomplishmentTypeLabels = {
+  collection_log: 'Collection log',
+  total_level: 'Total level',
+  ehb: 'Efficient hours bossed',
+  ehp: 'Efficient hours played',
+  maxed: 'Maxed',
+  elite_diary: 'Achievement diary',
+  diary_cape: 'Achievement diary',
+  combat_achievement: 'Combat achievements',
+  inferno: 'The Inferno',
+  colosseum: 'Fortis Colosseum',
+  blood_torva: 'Cosmetic',
+  radiant_oathplate: 'Cosmetic',
+  toa_cursed_phalanx: 'Tombs of Amascut',
+  pet: 'Pet',
+} as const satisfies Record<AccomplishmentType, string>;
+
+/**
+ * The icon for each type, as an OSRS Wiki image name (resolved through
+ * `formatWikiImageUrl`, exactly like collection-log item images).
+ *
+ * A row may override this with its own `iconItemName` where the accomplishment
+ * names a specific item — a pet is its own picture. Every name here has been
+ * checked against the wiki; a rename shows up as the fallback avatar in
+ * `ItemImageWithFallback` rather than a broken image.
+ */
+export const accomplishmentTypeIcons = {
+  collection_log: 'Collection log',
+  total_level: 'Skills icon',
+  ehb: 'Slayer icon',
+  ehp: 'Stats icon',
+  maxed: 'Max cape',
+  elite_diary: 'Achievement Diaries',
+  diary_cape: 'Achievement diary cape',
+  combat_achievement: 'Combat achievements',
+  inferno: 'Infernal cape',
+  colosseum: "Dizana's quiver (uncharged)",
+  // The wiki has no image filed under "Blood torva" — the blood-dyed Torva is
+  // the sanguine ornament kit applied to the platebody.
+  blood_torva: 'Sanguine torva platebody',
+  radiant_oathplate: 'Radiant oathplate chest',
+  toa_cursed_phalanx: 'Cursed phalanx',
+  pet: 'Collection log',
+} as const satisfies Record<AccomplishmentType, string>;

--- a/apps/web/app/utils/detect-accomplishments.spec.ts
+++ b/apps/web/app/utils/detect-accomplishments.spec.ts
@@ -1,0 +1,264 @@
+import { maximumTotalLevel } from '@/app/schemas/osrs';
+import { milestoneThresholds } from '@/config/accomplishments';
+import {
+  AccomplishmentSnapshot,
+  detectAccomplishments,
+  eliteDiaryLocationsFrom,
+} from './detect-accomplishments';
+
+const emptySnapshot: AccomplishmentSnapshot = {
+  collectionLogCount: 0,
+  totalLevel: 0,
+  ehb: 0,
+  ehp: 0,
+  combatAchievementTier: 'None',
+  tzhaarCape: 'None',
+  hasBloodTorva: false,
+  hasRadiantOathplate: false,
+  hasDizanasQuiver: false,
+  hasAchievementDiaryCape: false,
+  eliteDiaryLocations: [],
+  acquiredItems: [],
+};
+
+function keysOf(snapshot: Partial<AccomplishmentSnapshot>) {
+  return detectAccomplishments({ ...emptySnapshot, ...snapshot }).map(
+    ({ key }) => key,
+  );
+}
+
+describe('detectAccomplishments', () => {
+  it('finds nothing for a fresh account', () => {
+    expect(detectAccomplishments(emptySnapshot)).toEqual([]);
+  });
+
+  /**
+   * The detector reports what a player *currently* qualifies for rather than
+   * what is new, so someone who arrives past several thresholds earns all of
+   * them. The unique key in the database is what stops them being announced
+   * twice — see `syncPlayerAccomplishments`.
+   */
+  it('awards every threshold reached, not just the highest', () => {
+    expect(keysOf({ collectionLogCount: 1100 })).toEqual([
+      'collection_log:100',
+      'collection_log:250',
+      'collection_log:500',
+      'collection_log:750',
+      'collection_log:1000',
+    ]);
+  });
+
+  it('withholds a threshold that has not been reached', () => {
+    expect(keysOf({ collectionLogCount: 99 })).toEqual([]);
+  });
+
+  it('awards a threshold on the exact boundary', () => {
+    expect(keysOf({ collectionLogCount: 100 })).toEqual(['collection_log:100']);
+  });
+
+  it.each(['ehb', 'ehp'] as const)(
+    'measures %s against its own ladder',
+    (type) => {
+      const [firstThreshold] = milestoneThresholds[type];
+
+      expect(keysOf({ [type]: firstThreshold })).toEqual([
+        `${type}:${firstThreshold}`,
+      ]);
+    },
+  );
+
+  it('labels a milestone with its threshold, not the current value', () => {
+    const [milestone] = detectAccomplishments({
+      ...emptySnapshot,
+      collectionLogCount: 1100,
+    });
+
+    expect(milestone.label).toBe('100 collection log slots');
+    expect(milestone.value).toBe(100);
+  });
+
+  it('recognises a maxed account on top of the total level ladder', () => {
+    expect(keysOf({ totalLevel: maximumTotalLevel })).toContain('maxed');
+  });
+
+  it('does not call an unmaxed account maxed', () => {
+    expect(keysOf({ totalLevel: maximumTotalLevel - 1 })).not.toContain(
+      'maxed',
+    );
+  });
+
+  /**
+   * Grandmaster implies Master, and both are worth announcing — the same rule
+   * as the milestone ladders.
+   */
+  it('awards every notable combat achievement tier up to the one reached', () => {
+    expect(keysOf({ combatAchievementTier: 'Grandmaster' })).toEqual([
+      'combat_achievement:Master',
+      'combat_achievement:Grandmaster',
+    ]);
+  });
+
+  it('stops at the tier actually reached', () => {
+    expect(keysOf({ combatAchievementTier: 'Master' })).toEqual([
+      'combat_achievement:Master',
+    ]);
+  });
+
+  it.each(['None', 'Easy', 'Medium', 'Hard', 'Elite'])(
+    'ignores the %s combat achievement tier',
+    (combatAchievementTier) => {
+      expect(keysOf({ combatAchievementTier })).toEqual([]);
+    },
+  );
+
+  it('awards an elite diary per region', () => {
+    expect(keysOf({ eliteDiaryLocations: ['Morytania', 'Karamja'] })).toEqual([
+      'elite_diary:Morytania',
+      'elite_diary:Karamja',
+    ]);
+  });
+
+  it('reads the Inferno off the infernal cape', () => {
+    expect(keysOf({ tzhaarCape: 'Infernal cape' })).toEqual(['inferno']);
+  });
+
+  it('does not read the Inferno off a fire cape', () => {
+    expect(keysOf({ tzhaarCape: 'Fire cape' })).toEqual([]);
+  });
+
+  it.each([
+    ['hasDizanasQuiver', 'colosseum'],
+    ['hasBloodTorva', 'blood_torva'],
+    ['hasRadiantOathplate', 'radiant_oathplate'],
+    ['hasAchievementDiaryCape', 'diary_cape'],
+  ] as const)('reads %s as %s', (flag, key) => {
+    expect(keysOf({ [flag]: true })).toEqual([key]);
+  });
+
+  describe('items', () => {
+    const petSnakeling = {
+      itemId: 12921,
+      itemName: 'Pet snakeling',
+      dateFirstLogged: new Date('2024-03-01T00:00:00.000Z'),
+    };
+
+    it('awards a pet, and lets it carry its own icon', () => {
+      const [pet] = detectAccomplishments({
+        ...emptySnapshot,
+        acquiredItems: [petSnakeling],
+      });
+
+      expect(pet).toEqual({
+        type: 'pet',
+        key: 'pet:12921',
+        label: 'Pet snakeling',
+        value: null,
+        iconItemName: 'Pet snakeling',
+        achievedAt: petSnakeling.dateFirstLogged,
+      });
+    });
+
+    it('ignores an item that is not a pet', () => {
+      expect(
+        keysOf({
+          acquiredItems: [
+            {
+              itemId: 4151,
+              itemName: 'Abyssal whip',
+              dateFirstLogged: new Date(),
+            },
+          ],
+        }),
+      ).toEqual([]);
+    });
+
+    /**
+     * The cursed phalanx is only obtainable at 500+ invocation, so the clog
+     * entry is the proof of the raid level.
+     */
+    it('reads a 500 invocation Tombs run off the cursed phalanx', () => {
+      const dateFirstLogged = new Date('2025-01-02T00:00:00.000Z');
+
+      const [phalanx] = detectAccomplishments({
+        ...emptySnapshot,
+        acquiredItems: [
+          { itemId: 27377, itemName: 'Cursed phalanx', dateFirstLogged },
+        ],
+      });
+
+      expect(phalanx.key).toBe('toa_cursed_phalanx');
+      expect(phalanx.achievedAt).toBe(dateFirstLogged);
+    });
+
+    /**
+     * The collection log is the only source that knows when something happened.
+     * Everything else is dated by the caller from the time of the run.
+     */
+    it('leaves the date open for accomplishments nothing can date', () => {
+      const [milestone] = detectAccomplishments({
+        ...emptySnapshot,
+        collectionLogCount: 100,
+      });
+
+      expect(milestone.achievedAt).toBeNull();
+    });
+  });
+
+  /**
+   * Every row goes into one insert keyed on `(player_name, accomplishment_key)`,
+   * so a key repeated inside a single detection would be a bug that only shows
+   * up against a live database.
+   */
+  it('never repeats a key within one detection', () => {
+    const keys = detectAccomplishments({
+      collectionLogCount: 1800,
+      totalLevel: maximumTotalLevel,
+      ehb: 3000,
+      ehp: 3000,
+      combatAchievementTier: 'Grandmaster',
+      tzhaarCape: 'Infernal cape',
+      hasBloodTorva: true,
+      hasRadiantOathplate: true,
+      hasDizanasQuiver: true,
+      hasAchievementDiaryCape: true,
+      eliteDiaryLocations: ['Morytania', 'Karamja'],
+      acquiredItems: [
+        {
+          itemId: 12921,
+          itemName: 'Pet snakeling',
+          dateFirstLogged: new Date(),
+        },
+        {
+          itemId: 27377,
+          itemName: 'Cursed phalanx',
+          dateFirstLogged: new Date(),
+        },
+      ],
+    }).map(({ key }) => key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('is stable across runs, so nothing is re-announced under a new key', () => {
+    const snapshot = { ...emptySnapshot, collectionLogCount: 600 };
+
+    expect(keysOf(snapshot)).toEqual(keysOf(snapshot));
+  });
+});
+
+describe('eliteDiaryLocationsFrom', () => {
+  /**
+   * Each diary row holds the player's *highest* tier for the region, so an
+   * Elite row is a finished Elite diary and anything below it is not.
+   */
+  it('keeps only completed elite diaries', () => {
+    expect(
+      eliteDiaryLocationsFrom([
+        { location: 'Morytania', tier: 'Elite', completed: true },
+        { location: 'Karamja', tier: 'Hard', completed: true },
+        { location: 'Varrock', tier: 'Elite', completed: false },
+        { location: 'Desert', tier: 'None', completed: false },
+      ]),
+    ).toEqual(['Morytania']);
+  });
+});

--- a/apps/web/app/utils/detect-accomplishments.ts
+++ b/apps/web/app/utils/detect-accomplishments.ts
@@ -1,0 +1,277 @@
+import {
+  AllPetItemIds,
+  CombatAchievementTier,
+  DiaryTier,
+  maximumTotalLevel,
+  skillsCount,
+  TzHaarCape,
+} from '@/app/schemas/osrs';
+import { AccomplishmentType } from '@/app/schemas/accomplishments';
+import {
+  cursedPhalanxItemName,
+  milestoneThresholds,
+  notableCombatAchievementTiers,
+} from '@/config/accomplishments';
+import { formatNumber } from './format-number';
+
+/**
+ * Everything the detector is allowed to look at. Assembled from the player row,
+ * their achievement diaries and their acquired items — deliberately a plain
+ * value so the rules below can be reasoned about and tested without a database.
+ */
+export interface AccomplishmentSnapshot {
+  collectionLogCount: number;
+  totalLevel: number;
+  ehb: number;
+  ehp: number;
+  combatAchievementTier: string;
+  tzhaarCape: string;
+  hasBloodTorva: boolean;
+  hasRadiantOathplate: boolean;
+  hasDizanasQuiver: boolean;
+  hasAchievementDiaryCape: boolean;
+  /** Diary locations the player has completed at Elite. */
+  eliteDiaryLocations: string[];
+  acquiredItems: AcquiredItemSnapshot[];
+}
+
+export interface AcquiredItemSnapshot {
+  itemId: number;
+  itemName: string;
+  dateFirstLogged: Date;
+}
+
+export interface DetectedAccomplishment {
+  type: AccomplishmentType;
+  /**
+   * Stable identity, and the dedupe key. Never derive this from anything that
+   * can change after the fact — the label and the count both can.
+   */
+  key: string;
+  label: string;
+  /** The threshold reached, for milestones. Null for one-off feats. */
+  value: number | null;
+  /** Overrides the type's icon where the accomplishment names its own item. */
+  iconItemName: string | null;
+  /**
+   * When it actually happened, where that is knowable — the collection log
+   * carries its own dates. Null means "we only know we can see it now", and the
+   * caller stamps it with the time of the run.
+   */
+  achievedAt: Date | null;
+}
+
+const petItemIds = new Set(AllPetItemIds);
+
+const combatAchievementTierOrder = CombatAchievementTier.options;
+
+function isAtLeastCombatAchievementTier(
+  tier: string,
+  required: CombatAchievementTier,
+) {
+  const reached = combatAchievementTierOrder.indexOf(
+    tier as CombatAchievementTier,
+  );
+
+  return (
+    reached >= 0 && reached >= combatAchievementTierOrder.indexOf(required)
+  );
+}
+
+/**
+ * Every threshold in `thresholds` that `value` has reached, as one
+ * accomplishment each.
+ *
+ * A player who arrives already past several thresholds earns all of them. That
+ * is what makes detection stateless: nothing has to remember which milestones
+ * were announced last time, because the unique key does that in the database.
+ */
+function detectMilestones(
+  type: keyof typeof milestoneThresholds,
+  value: number,
+  label: (threshold: number) => string,
+): DetectedAccomplishment[] {
+  return milestoneThresholds[type]
+    .filter((threshold) => value >= threshold)
+    .map((threshold) => ({
+      type,
+      key: `${type}:${threshold}`,
+      label: label(threshold),
+      value: threshold,
+      iconItemName: null,
+      achievedAt: null,
+    }));
+}
+
+/**
+ * Everything the player *currently* qualifies for — not what is new.
+ *
+ * The caller inserts these `on conflict do nothing`, so re-running is free and
+ * a skipped run is caught up rather than lost. The price is that this function
+ * can never announce something it cannot still see: a stat that goes backwards
+ * (a de-ironed account, a Temple correction) keeps the row it already earned,
+ * which is the behaviour we want anyway.
+ */
+export function detectAccomplishments(
+  snapshot: AccomplishmentSnapshot,
+): DetectedAccomplishment[] {
+  const accomplishments: DetectedAccomplishment[] = [
+    ...detectMilestones(
+      'collection_log',
+      snapshot.collectionLogCount,
+      (threshold) => `${formatNumber(threshold)} collection log slots`,
+    ),
+    ...detectMilestones(
+      'total_level',
+      snapshot.totalLevel,
+      (threshold) => `${formatNumber(threshold)} total level`,
+    ),
+    ...detectMilestones(
+      'ehb',
+      snapshot.ehb,
+      (threshold) => `${formatNumber(threshold)} efficient hours bossed`,
+    ),
+    ...detectMilestones(
+      'ehp',
+      snapshot.ehp,
+      (threshold) => `${formatNumber(threshold)} efficient hours played`,
+    ),
+  ];
+
+  if (snapshot.totalLevel >= maximumTotalLevel) {
+    accomplishments.push({
+      type: 'maxed',
+      key: 'maxed',
+      label: `Maxed — level 99 in all ${skillsCount} skills`,
+      value: maximumTotalLevel,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  // Only Elite counts. The lower tiers are a step towards it rather than
+  // something the clan celebrates, and the diaries table stores the player's
+  // highest tier per region, so an Elite row is a completed Elite diary.
+  snapshot.eliteDiaryLocations.forEach((location) => {
+    accomplishments.push({
+      type: 'elite_diary',
+      key: `elite_diary:${location}`,
+      label: `${location} elite diary`,
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  });
+
+  if (snapshot.hasAchievementDiaryCape) {
+    accomplishments.push({
+      type: 'diary_cape',
+      key: 'diary_cape',
+      label: 'Achievement diary cape',
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  // Grandmaster implies Master, and a player who arrives at Grandmaster earns
+  // both — the same rule as the milestone ladders above.
+  notableCombatAchievementTiers
+    .filter((tier) =>
+      isAtLeastCombatAchievementTier(snapshot.combatAchievementTier, tier),
+    )
+    .forEach((tier) => {
+      accomplishments.push({
+        type: 'combat_achievement',
+        key: `combat_achievement:${tier}`,
+        label: `${tier} combat achievements`,
+        value: null,
+        iconItemName: null,
+        achievedAt: null,
+      });
+    });
+
+  if (snapshot.tzhaarCape === TzHaarCape.enum['Infernal cape']) {
+    accomplishments.push({
+      type: 'inferno',
+      key: 'inferno',
+      label: 'Completed the Inferno',
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  if (snapshot.hasDizanasQuiver) {
+    accomplishments.push({
+      type: 'colosseum',
+      key: 'colosseum',
+      label: 'Completed the Fortis Colosseum',
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  if (snapshot.hasBloodTorva) {
+    accomplishments.push({
+      type: 'blood_torva',
+      key: 'blood_torva',
+      label: 'Blood torva',
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  if (snapshot.hasRadiantOathplate) {
+    accomplishments.push({
+      type: 'radiant_oathplate',
+      key: 'radiant_oathplate',
+      label: 'Radiant oathplate',
+      value: null,
+      iconItemName: null,
+      achievedAt: null,
+    });
+  }
+
+  snapshot.acquiredItems.forEach((item) => {
+    if (item.itemName === cursedPhalanxItemName) {
+      accomplishments.push({
+        type: 'toa_cursed_phalanx',
+        key: 'toa_cursed_phalanx',
+        label: 'Cursed phalanx — Tombs of Amascut at 500 invocation',
+        value: null,
+        iconItemName: null,
+        achievedAt: item.dateFirstLogged,
+      });
+    }
+
+    if (petItemIds.has(item.itemId)) {
+      accomplishments.push({
+        type: 'pet',
+        key: `pet:${item.itemId}`,
+        label: item.itemName,
+        value: null,
+        // A pet is its own picture, so the row overrides the type's icon.
+        iconItemName: item.itemName,
+        achievedAt: item.dateFirstLogged,
+      });
+    }
+  });
+
+  return accomplishments;
+}
+
+/**
+ * The diary locations a player has completed at Elite, from the stored diary
+ * rows. Each row holds the player's *highest* tier for that region, so Elite is
+ * only ever present once the region is finished.
+ */
+export function eliteDiaryLocationsFrom(
+  diaries: { location: string; tier: string; completed: boolean }[],
+): string[] {
+  return diaries
+    .filter((diary) => diary.completed && diary.tier === DiaryTier.enum.Elite)
+    .map((diary) => diary.location);
+}

--- a/apps/web/config/accomplishments.ts
+++ b/apps/web/config/accomplishments.ts
@@ -1,0 +1,38 @@
+import { MilestoneAccomplishmentType } from '@/app/schemas/accomplishments';
+
+/**
+ * The thresholds that turn a stat into news.
+ *
+ * These are deliberately sparse. Every threshold a member crosses becomes a row
+ * in the feed, so a tight ladder would bury the one-off feats (an inferno cape,
+ * a pet) under a stream of round numbers. Spacing widens as the numbers get
+ * bigger, because the effort between them does too.
+ *
+ * They are also **append-only in practice**: lowering a threshold retroactively
+ * announces it for everyone who is already past it, since detection is stateless
+ * (see `detectAccomplishments`). Raising or removing one is safe — the rows
+ * already written simply stop being re-detected.
+ */
+export const milestoneThresholds = {
+  collection_log: [100, 250, 500, 750, 1000, 1250, 1500, 1750],
+  // Below 1,500 is not yet a milestone; `maxed` covers the top of the ladder.
+  total_level: [1500, 1750, 2000, 2100, 2200, 2300],
+  ehb: [100, 250, 500, 1000, 1500, 2000, 3000],
+  ehp: [100, 250, 500, 1000, 1500, 2000, 3000],
+} as const satisfies Record<MilestoneAccomplishmentType, readonly number[]>;
+
+/**
+ * The combat achievement tiers worth announcing. The lower tiers are a step on
+ * the way rather than an accomplishment in their own right, and the clan is an
+ * ironman clan — Master and Grandmaster are the ones that mean something.
+ */
+export const notableCombatAchievementTiers = ['Master', 'Grandmaster'] as const;
+
+/**
+ * Clogging the Cursed phalanx is only possible at 500+ invocation, so the item
+ * is the proof of the raid level rather than a drop worth noting on its own.
+ */
+export const cursedPhalanxItemName = 'Cursed phalanx';
+
+/** How many accomplishments the homepage and dashboard feeds show. */
+export const accomplishmentFeedSize = 10;

--- a/apps/web/drizzle/0019_third_yellow_claw.sql
+++ b/apps/web/drizzle/0019_third_yellow_claw.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."accomplishment_type" AS ENUM('collection_log', 'total_level', 'ehb', 'ehp', 'maxed', 'elite_diary', 'diary_cape', 'combat_achievement', 'inferno', 'colosseum', 'blood_torva', 'radiant_oathplate', 'toa_cursed_phalanx', 'pet');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "player_accomplishments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"player_name" varchar(12) NOT NULL,
+	"type" "accomplishment_type" NOT NULL,
+	"accomplishment_key" text NOT NULL,
+	"label" text NOT NULL,
+	"value" real,
+	"icon_item_name" text,
+	"is_backfilled" boolean DEFAULT false NOT NULL,
+	"achieved_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "player_accomplishments_player_name_accomplishment_key_unique" UNIQUE("player_name","accomplishment_key")
+);
+--> statement-breakpoint
+ALTER TABLE "players" ADD COLUMN "accomplishments_backfilled_at" timestamp;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "player_accomplishments_achieved_at_idx" ON "player_accomplishments" USING btree ("achieved_at");

--- a/apps/web/drizzle/meta/0019_snapshot.json
+++ b/apps/web/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,733 @@
+{
+  "id": "fce4c64d-2f63-4903-bcd6-37f164c765fc",
+  "prevId": "e61d640e-7de6-4eae-aba9-c2fe19c96f74",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.player_accomplishments": {
+      "name": "player_accomplishments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "accomplishment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accomplishment_key": {
+          "name": "accomplishment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_item_name": {
+          "name": "icon_item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_backfilled": {
+          "name": "is_backfilled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_accomplishments_achieved_at_idx": {
+          "name": "player_accomplishments_achieved_at_idx",
+          "columns": [
+            {
+              "expression": "achieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_accomplishments_player_name_accomplishment_key_unique": {
+          "name": "player_accomplishments_player_name_accomplishment_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "accomplishment_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_achievement_diaries": {
+      "name": "player_achievement_diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_acquired_items": {
+      "name": "player_acquired_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_category": {
+          "name": "item_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_first_logged": {
+          "name": "date_first_logged",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_acquired_items_item_id_idx": {
+          "name": "player_acquired_items_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_acquired_items_player_name_item_id_unique": {
+          "name": "player_acquired_items_player_name_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_rank_ups": {
+      "name": "player_rank_ups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "old_rank": {
+          "name": "old_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_rank": {
+          "name": "new_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ehb": {
+          "name": "ehb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ehp": {
+          "name": "ehp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_achievement_tier": {
+          "name": "combat_achievement_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_link": {
+          "name": "proof_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_log_count": {
+          "name": "collection_log_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_total": {
+          "name": "collection_log_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_level": {
+          "name": "total_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1154
+        },
+        "clue_count_beginner": {
+          "name": "clue_count_beginner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_easy": {
+          "name": "clue_count_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_medium": {
+          "name": "clue_count_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_hard": {
+          "name": "clue_count_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_elite": {
+          "name": "clue_count_elite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_master": {
+          "name": "clue_count_master",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tzhaar_cape": {
+          "name": "tzhaar_cape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "has_blood_torva": {
+          "name": "has_blood_torva",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_radiant_oathplate": {
+          "name": "has_radiant_oathplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dizanas_quiver": {
+          "name": "has_dizanas_quiver",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_achievement_diary_cape": {
+          "name": "has_achievement_diary_cape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "combat_bonus_points": {
+          "name": "combat_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skilling_bonus_points": {
+          "name": "skilling_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_bonus_points": {
+          "name": "collection_log_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notable_items_bonus_points": {
+          "name": "notable_items_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile_only": {
+          "name": "is_mobile_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gim_group_name": {
+          "name": "gim_group_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "accomplishments_backfilled_at": {
+          "name": "accomplishments_backfilled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_player_name_lower_unique": {
+          "name": "players_player_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"player_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_role_changes": {
+      "name": "staff_role_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_role": {
+          "name": "old_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_role": {
+          "name": "new_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_player_name": {
+          "name": "changed_by_player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_discord_user_id": {
+          "name": "changed_by_discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_role_changes_player_name_idx": {
+          "name": "staff_role_changes_player_name_idx",
+          "columns": [
+            {
+              "expression": "player_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.accomplishment_type": {
+      "name": "accomplishment_type",
+      "schema": "public",
+      "values": [
+        "collection_log",
+        "total_level",
+        "ehb",
+        "ehp",
+        "maxed",
+        "elite_diary",
+        "diary_cape",
+        "combat_achievement",
+        "inferno",
+        "colosseum",
+        "blood_torva",
+        "radiant_oathplate",
+        "toa_cursed_phalanx",
+        "pet"
+      ]
+    },
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "main",
+        "ironman",
+        "hardcore_ironman",
+        "ultimate_ironman",
+        "group_ironman",
+        "hardcore_group_ironman",
+        "unranked_group_ironman"
+      ]
+    },
+    "public.staff_role": {
+      "name": "staff_role",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "admin",
+        "deputy_owner",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1787259498482,
       "tag": "0018_steady_mach_iv",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1787301762382,
+      "tag": "0019_third_yellow_claw",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/accomplishment-operations.ts
+++ b/apps/web/lib/db/accomplishment-operations.ts
@@ -1,0 +1,162 @@
+import { and, eq, inArray, or } from 'drizzle-orm';
+import {
+  detectAccomplishments,
+  eliteDiaryLocationsFrom,
+} from '@/app/utils/detect-accomplishments';
+import { AllPetItemIds } from '@/app/schemas/osrs';
+import { cursedPhalanxItemName } from '@/config/accomplishments';
+import { db } from './index';
+import {
+  playerAccomplishments,
+  playerAchievementDiaries,
+  playerAcquiredItems,
+  players,
+} from './schema';
+
+export interface SyncPlayerAccomplishmentsResult {
+  /** How many accomplishments the player currently qualifies for. */
+  detected: number;
+  /** How many of those were new, and so written. */
+  recorded: number;
+  /**
+   * Whether this was the player's first pass, in which case the rows written
+   * are marked as backfill and kept out of the feed.
+   */
+  backfilled: boolean;
+}
+
+/**
+ * Brings a player's accomplishments up to date.
+ *
+ * Safe to call as often as you like: detection is stateless and every row is
+ * inserted `on conflict do nothing`, so this is a no-op once a player has
+ * stopped achieving things. It reads the player's stored record rather than any
+ * live API, so it belongs *after* whatever refreshed that record.
+ *
+ * The first pass over a player is recorded as backfill. Members join with a
+ * whole account behind them and the detector reports everything it can see, so
+ * without this the feed's first render would be a decade of other people's
+ * history — see `players.accomplishments_backfilled_at`.
+ */
+export async function syncPlayerAccomplishments(
+  playerName: string,
+): Promise<SyncPlayerAccomplishmentsResult> {
+  const [player] = await db
+    .select({
+      playerName: players.playerName,
+      collectionLogCount: players.collectionLogCount,
+      totalLevel: players.totalLevel,
+      ehb: players.ehb,
+      ehp: players.ehp,
+      combatAchievementTier: players.combatAchievementTier,
+      tzhaarCape: players.tzhaarCape,
+      hasBloodTorva: players.hasBloodTorva,
+      hasRadiantOathplate: players.hasRadiantOathplate,
+      hasDizanasQuiver: players.hasDizanasQuiver,
+      hasAchievementDiaryCape: players.hasAchievementDiaryCape,
+      accomplishmentsBackfilledAt: players.accomplishmentsBackfilledAt,
+    })
+    .from(players)
+    .where(eq(players.playerName, playerName))
+    .limit(1);
+
+  if (!player) {
+    return { detected: 0, recorded: 0, backfilled: false };
+  }
+
+  const [diaries, acquiredItems] = await Promise.all([
+    db
+      .select({
+        location: playerAchievementDiaries.location,
+        tier: playerAchievementDiaries.tier,
+        completed: playerAchievementDiaries.completed,
+      })
+      .from(playerAchievementDiaries)
+      .where(eq(playerAchievementDiaries.playerName, playerName)),
+    // Only the two item-driven accomplishments — there is no reason to pull a
+    // member's entire collection log to find out whether they own a pet.
+    db
+      .select({
+        itemId: playerAcquiredItems.itemId,
+        itemName: playerAcquiredItems.itemName,
+        dateFirstLogged: playerAcquiredItems.dateFirstLogged,
+      })
+      .from(playerAcquiredItems)
+      .where(
+        and(
+          eq(playerAcquiredItems.playerName, playerName),
+          or(
+            inArray(playerAcquiredItems.itemId, AllPetItemIds),
+            eq(playerAcquiredItems.itemName, cursedPhalanxItemName),
+          ),
+        ),
+      ),
+  ]);
+
+  const detected = detectAccomplishments({
+    collectionLogCount: player.collectionLogCount,
+    totalLevel: player.totalLevel,
+    ehb: player.ehb,
+    ehp: player.ehp,
+    combatAchievementTier: player.combatAchievementTier,
+    tzhaarCape: player.tzhaarCape,
+    hasBloodTorva: player.hasBloodTorva,
+    hasRadiantOathplate: player.hasRadiantOathplate,
+    hasDizanasQuiver: player.hasDizanasQuiver,
+    hasAchievementDiaryCape: player.hasAchievementDiaryCape,
+    eliteDiaryLocations: eliteDiaryLocationsFrom(diaries),
+    acquiredItems,
+  });
+
+  const isBackfill = player.accomplishmentsBackfilledAt === null;
+  const now = new Date();
+
+  const recorded = await db.transaction(async (tx) => {
+    const inserted =
+      detected.length > 0
+        ? await tx
+            .insert(playerAccomplishments)
+            .values(
+              detected.map((accomplishment) => ({
+                playerName,
+                type: accomplishment.type,
+                accomplishmentKey: accomplishment.key,
+                label: accomplishment.label,
+                value: accomplishment.value,
+                iconItemName: accomplishment.iconItemName,
+                isBackfilled: isBackfill,
+                // The collection log knows when a drop happened; nothing else
+                // does, so the rest are dated from this run.
+                achievedAt: accomplishment.achievedAt ?? now,
+              })),
+            )
+            .onConflictDoNothing({
+              target: [
+                playerAccomplishments.playerName,
+                playerAccomplishments.accomplishmentKey,
+              ],
+            })
+            .returning({ id: playerAccomplishments.id })
+        : [];
+
+    if (isBackfill) {
+      // Set unconditionally, including for a player who qualified for nothing —
+      // otherwise a brand new account would stay in backfill mode forever and
+      // its first real accomplishment would be silently swallowed.
+      await tx
+        .update(players)
+        .set({ accomplishmentsBackfilledAt: now })
+        .where(eq(players.playerName, playerName));
+    }
+
+    return inserted.length;
+  });
+
+  if (recorded > 0) {
+    console.log(
+      `Recorded ${recorded} ${isBackfill ? 'backfilled ' : ''}accomplishment(s) for ${playerName}`,
+    );
+  }
+
+  return { detected: detected.length, recorded, backfilled: isBackfill };
+}

--- a/apps/web/lib/db/player-operations.ts
+++ b/apps/web/lib/db/player-operations.ts
@@ -5,6 +5,7 @@ import {
   playerAcquiredItems,
   playerAchievementDiaries,
   playerRankUps,
+  playerAccomplishments,
   type Player,
   type NewPlayer,
   type PlayerAcquiredItem,
@@ -13,6 +14,7 @@ import {
 } from './schema';
 import { getCategoryFromItemName } from './item-mapping-utils';
 import { calculatePlayerPoints } from '@/app/rank-calculator/utils/calculate-player-points';
+import { syncPlayerAccomplishments } from './accomplishment-operations';
 import type { PlayerDetailsResponse } from '@/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details';
 import { TempleOSRSCollectionLogItem } from '@/app/schemas/temple-api';
 import type { AccountType } from '@/app/schemas/staff';
@@ -134,6 +136,9 @@ export async function deletePlayer(
     await tx
       .delete(playerRankUps)
       .where(eq(playerRankUps.playerName, playerName));
+    await tx
+      .delete(playerAccomplishments)
+      .where(eq(playerAccomplishments.playerName, playerName));
 
     // Delete the player record
     await tx.delete(players).where(eq(players.playerName, playerName));
@@ -811,7 +816,7 @@ export async function processPlayerData(
     .limit(1);
 
   try {
-    const player = existingPlayer
+    let player = existingPlayer
       ? // Player exists - update with new data (ownership validated in updatePlayerWithFullData)
         (await updatePlayerWithFullData(playerData, discordUserId))!
       : // Player doesn't exist - create new record (no ownership validation needed for new players)
@@ -826,15 +831,24 @@ export async function processPlayerData(
     try {
       const { totalPoints } = await calculatePlayerPoints(playerData);
 
-      return (await updatePlayerPoints(playerName, totalPoints)) ?? player;
+      player = (await updatePlayerPoints(playerName, totalPoints)) ?? player;
     } catch (error) {
       console.error(
         `Failed to recalculate points for ${playerName}, keeping the stored total:`,
         error,
       );
-
-      return player;
     }
+
+    // Accomplishments are read back off the record we just wrote, so this has
+    // to come last. Never fatal: a member's stats landing is the point of this
+    // call, and noticing what they add up to can wait for the next run.
+    try {
+      await syncPlayerAccomplishments(playerName);
+    } catch (error) {
+      console.error(`Failed to sync accomplishments for ${playerName}:`, error);
+    }
+
+    return player;
   } catch (error) {
     console.error(`Failed to process player data for ${playerName}:`, error);
     throw error; // Re-throw to let calling code handle the error appropriately

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -31,6 +31,34 @@ export const staffRoleEnum = pgEnum('staff_role', [
   'owner',
 ]);
 
+/**
+ * The kind of accomplishment, and the *only* thing that decides its icon and
+ * its grouping in the feed — see `config/accomplishments.ts`, which maps each
+ * value to a wiki image and a display name.
+ *
+ * Adding a value here is the whole cost of adding a new accomplishment: the
+ * detector in `app/utils/detect-accomplishments.ts` decides when it is earned,
+ * and the config decides how it looks.
+ */
+export const accomplishmentTypeEnum = pgEnum('accomplishment_type', [
+  // Threshold milestones — earned repeatedly, once per threshold crossed.
+  'collection_log',
+  'total_level',
+  'ehb',
+  'ehp',
+  // One-off feats.
+  'maxed',
+  'elite_diary',
+  'diary_cape',
+  'combat_achievement',
+  'inferno',
+  'colosseum',
+  'blood_torva',
+  'radiant_oathplate',
+  'toa_cursed_phalanx',
+  'pet',
+]);
+
 export const accountTypeEnum = pgEnum('account_type', [
   'main',
   'ironman',
@@ -123,6 +151,16 @@ export const players = pgTable(
     // so they can be restored automatically if they become active again.
     isActive: boolean('is_active').notNull().default(true),
 
+    // When this player's accomplishments were first detected.
+    //
+    // The detector reports everything a player *currently* qualifies for, so
+    // the first pass over an existing member would announce a decade of
+    // achievements at once. That first pass is instead recorded as backfill
+    // (`player_accomplishments.is_backfilled`) and kept out of the feed; this
+    // column is what tells the two passes apart, and it must be per-player
+    // because members keep joining with a full account behind them.
+    accomplishmentsBackfilledAt: timestamp('accomplishments_backfilled_at'),
+
     // Metadata
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -188,6 +226,7 @@ export const playersRelations = relations(players, ({ many }) => ({
   acquiredItems: many(playerAcquiredItems),
   achievementDiaries: many(playerAchievementDiaries),
   rankUps: many(playerRankUps),
+  accomplishments: many(playerAccomplishments),
 }));
 
 export const playerAcquiredItemsRelations = relations(
@@ -226,6 +265,83 @@ export const playerRankUpsRelations = relations(playerRankUps, ({ one }) => ({
     references: [players.playerName],
   }),
 }));
+
+/**
+ * Notable things a member has done, as a feed alongside rank ups and clogs.
+ *
+ * Detection is *stateless*: `detectAccomplishments` reports everything a player
+ * currently qualifies for and every row is inserted `on conflict do nothing`
+ * against `(player_name, accomplishment_key)`. Nothing has to diff against the
+ * previous run, so a re-run is free and a missed run is caught up rather than
+ * lost — but it also means the row's own timestamp is the only record of
+ * *when* something happened, which is why `achieved_at` is set explicitly
+ * (from the collection log's own date where there is one) rather than defaulted.
+ */
+export const playerAccomplishments = pgTable(
+  'player_accomplishments',
+  {
+    id: uuid('id')
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    playerName: varchar('player_name', { length: 12 }).notNull(),
+    type: accomplishmentTypeEnum('type').notNull(),
+
+    /**
+     * Stable identity of this exact accomplishment, e.g. `collection_log:1000`
+     * or `elite_diary:Morytania`. This is the dedupe key, so it must never
+     * encode anything that can change after the fact (a display label, a
+     * count) or the same feat would be announced twice.
+     */
+    accomplishmentKey: text('accomplishment_key').notNull(),
+
+    /** Rendered as-is in the feed, e.g. "1,000 collection log slots". */
+    label: text('label').notNull(),
+
+    /** The threshold reached, for milestones. Null for one-off feats. */
+    value: real('value'),
+
+    /**
+     * Overrides the type's configured icon where the accomplishment names its
+     * own item — a pet is its own picture. Null means use the type's icon.
+     */
+    iconItemName: text('icon_item_name'),
+
+    /**
+     * True for everything found in the player's very first detection pass:
+     * real, but not news. Kept out of the feed, and the reason the feed does
+     * not explode the first time this runs over an established clan.
+     */
+    isBackfilled: boolean('is_backfilled').notNull().default(false),
+
+    achievedAt: timestamp('achieved_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    // One row per accomplishment per player — this is what makes re-running
+    // the detector a no-op rather than a duplicate.
+    playerAccomplishmentUnique: unique().on(
+      table.playerName,
+      table.accomplishmentKey,
+    ),
+    // The feed's only query: newest first across every player.
+    achievedAtIdx: index('player_accomplishments_achieved_at_idx').on(
+      table.achievedAt,
+    ),
+  }),
+);
+
+export type PlayerAccomplishment = typeof playerAccomplishments.$inferSelect;
+export type NewPlayerAccomplishment = typeof playerAccomplishments.$inferInsert;
+
+export const playerAccomplishmentsRelations = relations(
+  playerAccomplishments,
+  ({ one }) => ({
+    player: one(players, {
+      fields: [playerAccomplishments.playerName],
+      references: [players.playerName],
+    }),
+  }),
+);
 
 /**
  * Every change to `players.staff_role`, and who made it.


### PR DESCRIPTION
<!-- member-summary:start -->
A new Accomplishments feed on the homepage and dashboard highlights clan milestones as members hit them — pets, Inferno and Colosseum completions, collection log and total level milestones, elite diaries and more.
<!-- member-summary:end -->

## What

A third activity feed, full width above the rank-up and collection-log columns on both the homepage and the dashboard. It covers the things members celebrate that are neither a promotion nor a single drop.

`player_accomplishments` (migration `0019`) holds one row per thing achieved, typed by an enum that also picks the icon. What counts today:

| | |
|---|---|
| **Thresholds** | collection log slots, total level, EHB, EHP |
| **Skilling** | maxed, elite diaries (per region), achievement diary cape |
| **Combat** | Master and Grandmaster combat achievements, the Inferno, the Fortis Colosseum |
| **Cosmetics** | blood torva, radiant oathplate |
| **Raids** | Cursed phalanx — only obtainable at 500 invocation |
| **Pets** | every pet, carrying its own picture |

Four files, one job each: the enum + icons (`app/schemas/accomplishments.ts`), the numbers (`config/accomplishments.ts`), the pure rule (`app/utils/detect-accomplishments.ts`), the write (`lib/db/accomplishment-operations.ts`). Adding a new accomplishment is a value in the enum, an icon, and a rule.

## Why it's built this way

**Detection is stateless.** `detectAccomplishments` reports everything a player *currently* qualifies for — never "what changed" — and every row is inserted `on conflict do nothing` against `(player_name, accomplishment_key)`. Nothing has to diff against the previous run, so re-running is free and a missed run is caught up rather than lost. It follows that a player crossing several thresholds at once earns all of them, and that Grandmaster CAs earn Master too.

Two things this makes load-bearing, both documented in CLAUDE.md: `accomplishment_key` is the identity and must never be built from a label or a live count, and **lowering** a threshold retroactively announces it for everyone already past it.

**The first pass over a player is backfill.** Members join with a whole account behind them, so the first detection would dump a decade of history into the feed at once. `players.accomplishments_backfilled_at` marks that a player has had their first pass; everything found in it is written `is_backfilled = true` and filtered out of the feed. The timestamp is set even when nothing was detected, so a brand-new account doesn't stay in backfill mode forever and swallow its first real accomplishment.

**No new endpoint.** `syncPlayerAccomplishments` hangs off `processPlayerData`, after the record it reads has been written — so `GET /api/update-all-players` and every calculator save both cover it. It's wrapped in its own try/catch: a member's stats landing is the point, and noticing what they add up to can wait for the next run.

Accomplishments also follow the player — `deletePlayer` removes them and the rename path in `edit-player-action.ts` moves them. Missing the rename would strand them and make the next pass re-earn the lot.

## Rebased onto current main — one conflict resolved by hand

#87 restructured `processPlayerData` at exactly the point this PR hooks into it, so both wanted the same lines. Resolved so **both** happen, in a deliberate order:

1. write the record
2. recalculate and store points
3. sync accomplishments — **last**, because it reads the record back

Each step has its own try/catch, so neither points nor accomplishments can fail the stats write that is the point of the call.

## Deploying — order matters

The deploy workflow does **not** run migrations, so this is manual:

1. **Merge**, and let it deploy
2. `yarn db:migrate` from `apps/web` — creates `player_accomplishments` and `players.accomplishments_backfilled_at`
3. `GET /api/update-all-players` **once** — the backfill pass

Between steps 1 and 2 the table doesn't exist yet. That degrades safely rather than breaking: `syncPlayerAccomplishments` throws into its own catch, the feed query returns `{ success: false }` → an empty array → and the feed hides itself entirely. It will log one error per player during that window, so keep the gap short.

Step 3 is what stops the feed exploding later: every existing member's history is recorded as backfill and kept invisible, so from then on the feed shows genuinely new things only.

## Not included

**No EHC milestone.** Nothing stores efficient-hours-collected per player — `petEhcRates` is points config, not a player stat — so there is no data to detect it from. Everything else on the brief is covered.

Accomplishments aren't rendered on the player profile modal yet, which is where the backfilled rows would earn their keep. Worth a follow-up.

## Tested

- `app/utils/detect-accomplishments.spec.ts` — 30 hermetic specs over the detector: thresholds (boundary, below, several at once), Grandmaster implying Master, Elite-only diaries, Inferno off the infernal cape but not a fire cape, pets and the cursed phalanx dating themselves from the collection log, and a guard that no key repeats within one detection.
- `yarn check-types` clean on the app project. The four pre-existing `submit-rank-calculator.spec.ts` errors are unchanged (verified against a clean tree).
- Full Jest suite diffed before and after: identical outcomes plus the new passing suite. The 10 failing suites are the drift CLAUDE.md already documents.
- Every wiki icon name checked against the live wiki (200s). Blood torva has no image under that name — it uses `Sanguine torva platebody`, the blood-dyed platebody.
- eslint and prettier clean.

**Not verified:** nothing was run against a database — no migration applied, so `syncPlayerAccomplishments`, the feed query and the rendered feed have not been exercised end to end. The dashboard is also behind the Discord auth gate and can't be checked headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

