### PR TITLE
Announce merged PRs to the clan Discord

### DIFF
--- a/.github/workflows/announce-merge.yaml
+++ b/.github/workflows/announce-merge.yaml
@@ -1,0 +1,95 @@
+name: Announce merge
+
+# Posts a short, member-facing note to the clan Discord whenever a pull request
+# lands on main, so members can see the site is actively being worked on.
+#
+# The note is NOT generated here — it is written by the PR author inside the
+# member-summary block in the PR body (see "Announcing a change" in CLAUDE.md).
+# This workflow only extracts it and posts it. A PR with no block is skipped
+# with a warning rather than announced badly.
+#
+# `pull_request_target` is used instead of `pull_request` so the webhook secret
+# is available even when the PR came from a fork. That trigger is only unsafe
+# when a workflow checks out and executes the PR's code — this one does neither.
+# It reads two fields off the event payload and posts them. Do not add a
+# checkout step here.
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+# Nothing here needs to write to the repository.
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post the member summary to Discord
+        env:
+          # Every one of these is untrusted input from a pull request, so they
+          # are passed through the environment and quoted at the point of use.
+          # Interpolating ${{ }} directly into a run: block would let a crafted
+          # PR title or body execute shell commands on this runner.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK_URL:-}" ]; then
+            echo "::warning::DISCORD_RELEASE_WEBHOOK is not set — skipping the announcement."
+            exit 0
+          fi
+
+          # Pull out everything between the delimiters. Tolerates whitespace
+          # inside the comment markers and CRLF line endings from the API.
+          summary=$(
+            printf '%s\n' "$PR_BODY" \
+              | tr -d '\r' \
+              | awk '
+                  /<!--[[:space:]]*member-summary:start[[:space:]]*-->/ { grab = 1; next }
+                  /<!--[[:space:]]*member-summary:end[[:space:]]*-->/   { grab = 0 }
+                  grab
+                ' \
+              | sed '/^[[:space:]]*$/d'
+          )
+
+          if [ -z "$summary" ]; then
+            echo "::warning::PR #${PR_NUMBER} has no member-summary block, so nothing was announced. See 'Announcing a change' in CLAUDE.md."
+            exit 0
+          fi
+
+          echo "Announcing PR #${PR_NUMBER}:"
+          echo "$summary"
+
+          # jq builds the payload so quotes, newlines and backslashes in the
+          # summary can't break out of the JSON.
+          payload=$(
+            jq -n \
+              --arg description "$summary" \
+              --arg url "$PR_URL" \
+              --arg footer "Irons' Grotto · #${PR_NUMBER}" \
+              '{
+                username: "Irons'"'"' Grotto",
+                embeds: [{
+                  title: "Site update",
+                  url: $url,
+                  description: $description,
+                  color: 3527322,
+                  footer: { text: $footer }
+                }]
+              }'
+          )
+
+          curl --fail-with-body --silent --show-error \
+            -H 'Content-Type: application/json' \
+            -X POST \
+            -d "$payload" \
+            "$WEBHOOK_URL"
+
+          echo "Posted."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,35 @@ open "$(gh pr view --json url --jq .url)"     # macOS: opens the PR in the defau
 
 `gh` is installed via Homebrew and authenticated as `mattlm0831`. The PR body should say what was **not** verified as well as what was — e.g. anything behind the Discord auth gate can't be checked headlessly.
 
+## Announcing a change — every PR body needs a member summary
+
+When a PR merges to `main`, `.github/workflows/announce-merge.yaml` posts a note to the clan Discord. It does **not** write that note — it greps the PR body for this block and posts what it finds verbatim:
+
+```markdown
+<!-- member-summary:start -->
+Your collection log now updates on the leaderboard as soon as you log a new item, instead of waiting for the nightly refresh.
+<!-- member-summary:end -->
+```
+
+**Include it in every PR.** A PR without the block is skipped with a warning — nothing is announced, and that release is invisible to members. The delimiters are HTML comments, so they don't render on GitHub; only the sentence shows.
+
+### How to write it
+
+This is read by **clan members**, not developers. They do not know what a data source is, they will never open the repo, and they don't care which file changed. One or two sentences, plain language, describing **what is different for them**.
+
+- **Say what they'll notice.** "Player profiles now open instantly" — not "memoised the profile fetch".
+- **No jargon, no identifiers.** No file names, function names, table names, library names, or PR/issue numbers.
+- **Technical work still gets announced** — framed by its effect, or as general upkeep. A migration, a refactor, a dependency bump: *"Behind-the-scenes upgrades to keep the site fast and reliable."* Vague is fine here; silence is not. **The point is to show the site is actively worked on**, so every merge says something.
+- **Present tense, active voice.** "The leaderboard now shows…", not "Added a thing that will show…".
+- **Don't oversell.** No "massive", no "revolutionary". Understated reads as competent.
+
+| Instead of | Write |
+|---|---|
+| Added `player_accomplishments` table + stateless detection hooked into `processPlayerData` | A new Accomplishments feed on the homepage shows milestones as members hit them — pets, inferno capes, collection log milestones and more. |
+| Fixed unawaited `db.transaction` in `approve-submission.ts` | Rank approvals now apply reliably every time. |
+| Bumped Drizzle, regenerated migrations, added indexes | Infrastructure upgrades to keep things running smoothly. |
+| Collapsed the Redis/Postgres split behind a single write path | Your calculator now saves changes automatically as you make them. |
+
 ## Drift canary
 `app/rank-calculator/utils/notable-item-points-drift.spec.ts` hits the **live wiki** and lists every notable item that currently renders `-`. Run it to see what's broken after wiki drift. (Networked — not a hermetic unit test.) `schemas/wiki.spec.ts` is the hermetic guard for the casing normalisation.
 


### PR DESCRIPTION
Members currently have no way to see that the site is being worked on. This posts a short note to the clan Discord whenever a PR lands on `main`.

<!-- member-summary:start -->
Site updates will now be posted to Discord as they go live, so you can see what's changed and what's being worked on.
<!-- member-summary:end -->

## How it works

The workflow does **not** write the note. The PR author writes it, in the PR body:

```markdown
<!-- member-summary:start -->
Your collection log now updates on the leaderboard as soon as you log a new item.
<!-- member-summary:end -->
```

The action greps that block out and posts it verbatim as a Discord embed. Delimiters are HTML comments, so they don't render on GitHub — only the sentence shows.

**Writing it by hand is the point.** The audience is clan members, so the note has to say what changed *for them*, not what changed in the code — and that judgement doesn't survive being derived from a diff or a commit message. `CLAUDE.md` now carries the convention, the tone rules, and a before/after table:

| Instead of | Write |
|---|---|
| Added `player_accomplishments` table + stateless detection | A new Accomplishments feed shows milestones as members hit them. |
| Fixed unawaited `db.transaction` in `approve-submission.ts` | Rank approvals now apply reliably every time. |
| Bumped Drizzle, regenerated migrations, added indexes | Infrastructure upgrades to keep things running smoothly. |

A PR with **no block is skipped with a warning** rather than announced badly. Purely technical work still gets announced — framed by its effect, or as general upkeep — because a silent release defeats the purpose of the feature.

## Two decisions worth reviewing

**`pull_request_target`, not `pull_request`.** Needed so the webhook secret is available for PRs from forks; with `pull_request` a fork merge would silently announce nothing. That trigger is only dangerous when a workflow *checks out and executes* the PR's code — this one reads two fields off the event payload and posts them. There's a comment in the file saying exactly that, and no checkout step. Please don't add one.

**The PR body is untrusted input.** It's passed through the environment and quoted at the point of use rather than interpolated into the shell with `${{ }}`, and the Discord payload is built with `jq`. This matters more than usual here: the repo is public, so anyone can open a PR containing a crafted body.

## Setup required before this does anything

Add a repository secret named **`DISCORD_RELEASE_WEBHOOK`** containing the webhook URL. Without it the workflow warns and exits cleanly rather than failing the run.

## Tested

Extraction and payload construction were run locally against three bodies:

- **Normal** — block extracted cleanly, correct JSON produced.
- **No block** — skipped, no post attempted.
- **Hostile** — a body containing `$(touch /tmp/PWNED)`, backticks, `"` quotes, backslashes and multiple lines. The command substitution stayed **inert literal text**, `/tmp/PWNED` was never created, and quotes/newlines/backslashes were correctly JSON-escaped.

Workflow YAML parses, trigger/types/`if`/env all resolve as intended. Embed colour `3527322` is `#35d29a`, the clan green from `globals.css`.

**Not verified:** no message has actually been posted to the live webhook — that would put a test message in front of clan members, so I left it for you to trigger. The first real merge is the true end-to-end test, and the workflow logs the extracted summary before posting, so a failure will be legible in the Actions run. Discord embed rendering is likewise unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)