### PR TITLE
Add the player-state field ownership model

### DIFF
--- a/apps/web/lib/player-state/field-ownership.spec.ts
+++ b/apps/web/lib/player-state/field-ownership.spec.ts
@@ -1,0 +1,196 @@
+import { getTableColumns } from 'drizzle-orm';
+import { players } from '@/lib/db/schema';
+import { CombatAchievementTier, TzHaarCape } from '@/app/schemas/osrs';
+import {
+  canWrite,
+  fieldOwnership,
+  fieldsWritableBy,
+  originsByOwner,
+  type FieldOwner,
+  type WriteOrigin,
+} from './field-ownership';
+
+const owners = Object.keys(originsByOwner) as FieldOwner[];
+
+describe('the table covers the players table exactly', () => {
+  /**
+   * The check that actually holds the line. Adding a column to `schema.ts`
+   * fails this until someone decides who owns it — which is the whole point,
+   * because the alternative is what happened before: an unclassified column
+   * gets whatever behaviour the nearest write path happens to give it.
+   *
+   * The mapped type in `field-ownership.ts` says the same thing at compile
+   * time, but a type error is one `as` away from being silenced and a red test
+   * is not.
+   */
+  it('classifies every column, and invents none', () => {
+    expect(Object.keys(fieldOwnership).sort()).toEqual(
+      Object.keys(getTableColumns(players)).sort(),
+    );
+  });
+
+  it('gives every column an owner and a merge rule', () => {
+    Object.entries(fieldOwnership).forEach(([field, rule]) => {
+      expect(owners).toContain(rule.owner);
+      expect(typeof rule.merge).toBe('function');
+      // Named in the failure message so a new column says which one it is.
+      expect({ field, hasRule: typeof rule.merge }).toEqual({
+        field,
+        hasRule: 'function',
+      });
+    });
+  });
+});
+
+describe('write permissions', () => {
+  it('lets a source write source and contested columns, and nothing else', () => {
+    expect(canWrite('source', 'source')).toBe(true);
+    expect(canWrite('contested', 'source')).toBe(true);
+    expect(canWrite('player', 'source')).toBe(false);
+    expect(canWrite('staff', 'source')).toBe(false);
+  });
+
+  /**
+   * The calculator form is `origin: 'player'`. It must not be able to assert a
+   * stat, a rank, or a staff role — the first would let someone type their own
+   * EHB, the last two would be privilege escalation.
+   */
+  it('lets a player write player and contested columns, and nothing else', () => {
+    expect(canWrite('player', 'player')).toBe(true);
+    expect(canWrite('contested', 'player')).toBe(true);
+    expect(canWrite('source', 'player')).toBe(false);
+    expect(canWrite('staff', 'player')).toBe(false);
+    expect(canWrite('identity', 'player')).toBe(false);
+    expect(canWrite('system', 'player')).toBe(false);
+  });
+
+  it.each(['source', 'player', 'staff', 'system'] as WriteOrigin[])(
+    'never accepts a derived column from %s',
+    (origin) => {
+      expect(canWrite('derived', origin)).toBe(false);
+    },
+  );
+
+  it('keeps the player out of every stat column', () => {
+    const playerWritable = fieldsWritableBy('player');
+
+    expect(playerWritable).not.toContain('ehb');
+    expect(playerWritable).not.toContain('ehp');
+    expect(playerWritable).not.toContain('totalLevel');
+    expect(playerWritable).not.toContain('collectionLogCount');
+    expect(playerWritable).not.toContain('clueCountMaster');
+    expect(playerWritable).not.toContain('points');
+    expect(playerWritable).not.toContain('rank');
+    expect(playerWritable).not.toContain('staffRole');
+  });
+
+  it('gives the player the claims nothing else can confirm', () => {
+    expect(fieldsWritableBy('player')).toEqual(
+      expect.arrayContaining([
+        'hasRadiantOathplate',
+        'proofLink',
+        'hasBloodTorva',
+        'combatAchievementTier',
+      ]),
+    );
+  });
+
+  /**
+   * A source going quiet is the failure mode this whole module was written for,
+   * so it must never be able to reach into the player's own claims.
+   */
+  it('keeps a source out of the player-only claims', () => {
+    const sourceWritable = fieldsWritableBy('source');
+
+    expect(sourceWritable).not.toContain('hasRadiantOathplate');
+    expect(sourceWritable).not.toContain('proofLink');
+    expect(sourceWritable).not.toContain('rank');
+  });
+});
+
+describe('the merge rules behave as the table promises', () => {
+  it('will not let a quiet source unset blood torva or the quiver', () => {
+    expect(fieldOwnership.hasBloodTorva.merge(true, undefined)).toBe(true);
+    expect(fieldOwnership.hasBloodTorva.merge(true, false)).toBe(true);
+    expect(fieldOwnership.hasDizanasQuiver.merge(true, false)).toBe(true);
+  });
+
+  it('will not let a quiet source zero a clue count', () => {
+    expect(fieldOwnership.clueCountMaster.merge(42, 0)).toBe(42);
+    expect(fieldOwnership.clueCountMaster.merge(42, undefined)).toBe(42);
+  });
+
+  it('lets a player clear their proof link', () => {
+    expect(
+      fieldOwnership.proofLink.merge('https://example.com', null),
+    ).toBeNull();
+    expect(fieldOwnership.proofLink.merge('https://example.com', '')).toBe('');
+  });
+
+  it('lets a player untick radiant oathplate', () => {
+    expect(fieldOwnership.hasRadiantOathplate.merge(true, false)).toBe(false);
+  });
+
+  it('never demotes a cape or a combat achievement tier', () => {
+    expect(fieldOwnership.tzhaarCape.merge('Infernal cape', 'Fire cape')).toBe(
+      'Infernal cape',
+    );
+    expect(
+      fieldOwnership.combatAchievementTier.merge('Grandmaster', 'Hard'),
+    ).toBe('Grandmaster');
+  });
+
+  it('promotes a cape or tier when the source is ahead', () => {
+    expect(fieldOwnership.tzhaarCape.merge('None', 'Infernal cape')).toBe(
+      'Infernal cape',
+    );
+    expect(fieldOwnership.combatAchievementTier.merge('Hard', 'Master')).toBe(
+      'Master',
+    );
+  });
+
+  /** Temple wins when it resolves; a null resolution is not an answer. */
+  it('lets Temple resolve account type but not erase it', () => {
+    expect(fieldOwnership.accountType.merge(null, 'ironman')).toBe('ironman');
+    expect(fieldOwnership.accountType.merge('group_ironman', null)).toBe(
+      'group_ironman',
+    );
+  });
+
+  it('lets EHB fall when Temple recalculates its rates', () => {
+    expect(fieldOwnership.ehb.merge(1200, 900)).toBe(900);
+  });
+
+  it('never lets a patch set a derived column', () => {
+    expect(fieldOwnership.points.merge(5000, 9999)).toBe(5000);
+    expect(fieldOwnership.hasAchievementDiaryCape.merge(false, true)).toBe(
+      false,
+    );
+  });
+});
+
+/**
+ * The ordered enums are ranked by an explicit list rather than their zod
+ * declaration order, so the two can drift apart. These catch that: add a cape
+ * or a tier and the ranking has to be updated before the merge rule can be
+ * trusted.
+ */
+describe('the ordinal rankings stay exhaustive', () => {
+  it('ranks every TzHaar cape', () => {
+    TzHaarCape.options.forEach((cape) => {
+      // A cape missing from the ranking merges as "lowest", which would
+      // silently make it unreachable.
+      expect(fieldOwnership.tzhaarCape.merge('None', cape)).toBe(
+        cape === 'None' ? 'None' : cape,
+      );
+    });
+  });
+
+  it('ranks every combat achievement tier', () => {
+    CombatAchievementTier.options.forEach((tier) => {
+      expect(fieldOwnership.combatAchievementTier.merge('None', tier)).toBe(
+        tier === 'None' ? 'None' : tier,
+      );
+    });
+  });
+});

--- a/apps/web/lib/player-state/field-ownership.ts
+++ b/apps/web/lib/player-state/field-ownership.ts
@@ -1,0 +1,247 @@
+import { CombatAchievementTier, TzHaarCape } from '@/app/schemas/osrs';
+import type { Player } from '@/lib/db/schema';
+import {
+  fillOnly,
+  immutable,
+  keepHighest,
+  keepHighestOrdinal,
+  keepTrue,
+  managed,
+  preferFresh,
+  preferResolved,
+  recomputed,
+  replace,
+  type MergeRule,
+} from './merge';
+
+/**
+ * Who a column belongs to.
+ *
+ * Before this table existed, no file said who was allowed to write what, so
+ * every write path re-derived the answer and they disagreed with each other.
+ * The disagreements were the bugs: a batch refresh would overwrite a member's
+ * blood torva with `false` because nothing said the player owned that claim,
+ * and a special-case object existed in `fetch-player-details` to protect
+ * exactly one field that someone had noticed.
+ */
+export type FieldOwner =
+  /** Fixed at creation, or moved only by a dedicated transaction (rename). */
+  | 'identity'
+  /** Bookkeeping the write path maintains itself. */
+  | 'system'
+  /** Third-party data — Temple, WikiSync, hiscores, Discord roles. */
+  | 'source'
+  /** Both a source and the player may write; the merge rule arbitrates. */
+  | 'contested'
+  /** The player's own claim. No source can confirm or deny it. */
+  | 'player'
+  /** A function of other columns. Never accepted as input. */
+  | 'derived'
+  /** Granted by approval or by an admin. Never by the calculator form. */
+  | 'staff';
+
+/** Where a write came from. */
+export type WriteOrigin = 'source' | 'player' | 'staff' | 'system';
+
+/**
+ * Which origins may write each class of column.
+ *
+ * `derived` accepts nothing: those columns are recomputed after the merge, so a
+ * caller asserting one would be asserting something the data contradicts.
+ */
+export const originsByOwner = {
+  identity: ['system'],
+  system: ['system'],
+  source: ['source'],
+  contested: ['source', 'player'],
+  player: ['player'],
+  derived: [],
+  staff: ['staff'],
+} as const satisfies Record<FieldOwner, readonly WriteOrigin[]>;
+
+export function canWrite(owner: FieldOwner, origin: WriteOrigin): boolean {
+  return (originsByOwner[owner] as readonly WriteOrigin[]).includes(origin);
+}
+
+export interface FieldRule<T> {
+  owner: FieldOwner;
+  merge: MergeRule<T>;
+  /** Why this rule, where the choice is not self-evident. */
+  why?: string;
+}
+
+/**
+ * Explicit rankings for the two ordered enums, rather than their declaration
+ * order. Reordering a zod enum for readability must not silently change which
+ * value beats which — and for `TzHaarCape` the declaration order is a
+ * by-product of `CollectionLogItemName.extract()`, which is no basis for a
+ * merge rule at all. Both are asserted exhaustive in the spec.
+ */
+const combatAchievementRanking = [
+  'None',
+  'Easy',
+  'Medium',
+  'Hard',
+  'Elite',
+  'Master',
+  'Grandmaster',
+] as const satisfies readonly CombatAchievementTier[];
+
+const tzhaarCapeRanking = [
+  'None',
+  'Fire cape',
+  'Infernal cape',
+] as const satisfies readonly TzHaarCape[];
+
+/**
+ * The single source of truth for who writes what, and how values combine.
+ *
+ * **Exhaustive over the `players` table** — `field-ownership.spec.ts` checks it
+ * against `getTableColumns(players)` at runtime, so adding a column fails the
+ * suite until it is classified here. That runtime check is the one that matters;
+ * the mapped type below is easy to silence with a cast, a red test is not.
+ */
+export const fieldOwnership: {
+  [K in keyof Player]: FieldRule<Player[K]>;
+} = {
+  // ---- identity -----------------------------------------------------------
+  playerName: {
+    owner: 'identity',
+    merge: immutable(),
+    why: 'The primary key. A rename moves it, and every child table with it, in one dedicated transaction.',
+  },
+  joinDate: { owner: 'identity', merge: immutable() },
+  discordUserId: {
+    owner: 'identity',
+    merge: fillOnly(),
+    why: 'Claimed once. Preserves the existing rule that an account with an owner never gets a new one.',
+  },
+
+  // ---- source: third-party stats ------------------------------------------
+  ehb: {
+    owner: 'source',
+    merge: preferFresh(),
+    why: 'Temple periodically recalculates its EHB rates, so this legitimately moves down.',
+  },
+  ehp: { owner: 'source', merge: preferFresh(), why: 'As ehb.' },
+  totalLevel: { owner: 'source', merge: keepHighest() },
+  totalXp: { owner: 'source', merge: keepHighest() },
+  collectionLogCount: {
+    owner: 'source',
+    merge: keepHighest(),
+    why: 'Read from whichever of Temple or the hiscores is further ahead; neither is reliably current.',
+  },
+  collectionLogTotal: {
+    owner: 'source',
+    merge: preferFresh(),
+    why: 'The size of the game, not a player stat. It moves when Jagex adds slots.',
+  },
+
+  // Clue counts only go up in game, so a lower reading means the source is
+  // incomplete. Guarding this is the fix for a Temple outage — which returns a
+  // null the old code mapped to 0 — wiping a member's clue counts entirely.
+  clueCountBeginner: { owner: 'source', merge: keepHighest() },
+  clueCountEasy: { owner: 'source', merge: keepHighest() },
+  clueCountMedium: { owner: 'source', merge: keepHighest() },
+  clueCountHard: { owner: 'source', merge: keepHighest() },
+  clueCountElite: { owner: 'source', merge: keepHighest() },
+  clueCountMaster: { owner: 'source', merge: keepHighest() },
+
+  // Derived from Discord roles, and absent when Discord is unreachable.
+  combatBonusPoints: { owner: 'source', merge: preferFresh() },
+  skillingBonusPoints: { owner: 'source', merge: preferFresh() },
+  collectionLogBonusPoints: { owner: 'source', merge: preferFresh() },
+  notableItemsBonusPoints: { owner: 'source', merge: preferFresh() },
+
+  // ---- contested: the player claims, a source may confirm -----------------
+  combatAchievementTier: {
+    owner: 'contested',
+    // Explicitly `<string>`: the column is a varchar, not a pg enum, so the
+    // ranking is narrower than what the database can actually hold. Anything
+    // off the ranking sorts lowest, which is the safe direction.
+    merge: keepHighestOrdinal<string>(combatAchievementRanking),
+    why: 'A player may tick a tier WikiSync has not caught up on. The submission diff flags a mismatch for a moderator rather than overwriting it.',
+  },
+  tzhaarCape: {
+    owner: 'contested',
+    merge: keepHighestOrdinal<string>(tzhaarCapeRanking),
+    why: 'As combatAchievementTier. Note the old write path could never set this back to None either, which this makes deliberate rather than accidental.',
+  },
+  hasBloodTorva: {
+    owner: 'contested',
+    merge: keepTrue(),
+    why: 'Derived from four WikiSync combat achievements. When WikiSync is unreachable the patch omits it; a `false` here used to be written straight over a true.',
+  },
+  hasDizanasQuiver: {
+    owner: 'contested',
+    merge: keepTrue(),
+    why: 'As hasBloodTorva, from a single combat achievement.',
+  },
+  accountType: {
+    owner: 'contested',
+    merge: preferResolved(),
+    why: 'Temple wins whenever it resolves anything, but a null resolution is the absence of an answer — it reports null for a real main and for a group ironman it has never heard of alike — so it must not erase a stored one.',
+  },
+  gimGroupName: {
+    owner: 'contested',
+    merge: preferResolved(),
+    why: 'Moves with accountType.',
+  },
+
+  // ---- player: nothing else can confirm these -----------------------------
+  hasRadiantOathplate: {
+    owner: 'player',
+    merge: replace(),
+    why: 'No data source exists, and it is absent from the submission diff, so no moderator sees it flagged either. Purely the player’s word, and they must be able to untick it.',
+  },
+  proofLink: {
+    owner: 'player',
+    merge: replace(),
+    why: 'Must be clearable — the old `if (proofLink)` guard made removing a link impossible.',
+  },
+  isMobileOnly: { owner: 'player', merge: replace() },
+
+  // ---- derived ------------------------------------------------------------
+  hasAchievementDiaryCape: {
+    owner: 'derived',
+    merge: recomputed(),
+    why: 'A function of the achievement diaries. The client already recomputes it on every diary change; this makes the server the authority.',
+  },
+  points: {
+    owner: 'derived',
+    merge: recomputed(),
+    why: 'Recomputed from the whole record. Accepting it as input is how it came to drift from the stats it is supposed to summarise.',
+  },
+
+  // ---- staff --------------------------------------------------------------
+  rank: {
+    owner: 'staff',
+    merge: replace(),
+    why: 'Only a submission approval or an admin moves this. The calculator computes a *prospective* rank; it does not grant one.',
+  },
+  staffRole: {
+    owner: 'staff',
+    merge: replace(),
+    why: 'Granted only from /admin, by someone who outranks the target.',
+  },
+
+  // ---- system -------------------------------------------------------------
+  isActive: {
+    owner: 'system',
+    merge: replace(),
+    why: 'Owned by the daily inactivity reconcile.',
+  },
+  createdAt: { owner: 'system', merge: immutable() },
+  updatedAt: {
+    owner: 'system',
+    merge: managed(),
+    why: 'Stamped by the write path on every commit.',
+  },
+};
+
+/** The columns a given origin is permitted to write. */
+export function fieldsWritableBy(origin: WriteOrigin): (keyof Player)[] {
+  return (Object.keys(fieldOwnership) as (keyof Player)[]).filter((field) =>
+    canWrite(fieldOwnership[field].owner, origin),
+  );
+}

--- a/apps/web/lib/player-state/merge.spec.ts
+++ b/apps/web/lib/player-state/merge.spec.ts
@@ -1,0 +1,174 @@
+import {
+  fillOnly,
+  immutable,
+  keepHighest,
+  keepHighestOrdinal,
+  keepTrue,
+  managed,
+  preferFresh,
+  preferResolved,
+  recomputed,
+  replace,
+  type MergeRule,
+} from './merge';
+
+/**
+ * The convention the whole design rests on. Asserted for every rule at once,
+ * because a rule that treats absence as a value is the bug class this module
+ * exists to remove — it is how a WikiSync outage came to unset blood torva and
+ * a Temple outage came to zero clue counts.
+ */
+describe('every rule treats undefined as unknown', () => {
+  /**
+   * Erases the value type so rules over different types can sit in one table.
+   * Safe here because every case only ever passes `undefined` as the incoming
+   * value, which each rule must handle regardless of `T`.
+   */
+  const anyRule = <T>(rule: MergeRule<T>) => rule as MergeRule<unknown>;
+
+  const rules: [string, MergeRule<unknown>, unknown][] = [
+    ['immutable', anyRule(immutable<string>()), 'kept'],
+    ['managed', anyRule(managed<string>()), 'kept'],
+    ['recomputed', anyRule(recomputed<string>()), 'kept'],
+    ['preferFresh', anyRule(preferFresh<string>()), 'kept'],
+    ['replace', anyRule(replace<string>()), 'kept'],
+    ['fillOnly', anyRule(fillOnly<string>()), 'kept'],
+    ['keepHighest', anyRule(keepHighest()), 7],
+    ['keepTrue', anyRule(keepTrue()), true],
+    ['keepHighestOrdinal', anyRule(keepHighestOrdinal(['a', 'kept'])), 'kept'],
+    ['preferResolved', anyRule(preferResolved<string>()), 'kept'],
+  ];
+
+  it.each(rules)('%s keeps the stored value', (_name, merge, stored) => {
+    expect(merge(stored, undefined)).toEqual(stored);
+  });
+});
+
+describe('immutable / managed / recomputed', () => {
+  it.each([
+    ['immutable', immutable<string>()],
+    ['managed', managed<string>()],
+    ['recomputed', recomputed<string>()],
+  ])('%s ignores an incoming value entirely', (_name, merge) => {
+    expect(merge('stored', 'incoming')).toBe('stored');
+  });
+});
+
+describe('preferFresh', () => {
+  const merge = preferFresh<number>();
+
+  /** Temple recalculates its EHB rates, so these legitimately fall. */
+  it('lets a value go down', () => {
+    expect(merge(120, 90)).toBe(90);
+  });
+
+  it('accepts zero as a real value', () => {
+    expect(merge(120, 0)).toBe(0);
+  });
+});
+
+describe('replace', () => {
+  /**
+   * The proof-link bug: `if (proofLink)` meant a link could be set but never
+   * cleared. Every falsy value here has to be a real choice.
+   */
+  it.each([null, '', false, 0])('writes %p over a stored value', (cleared) => {
+    expect(replace<unknown>()('something', cleared)).toEqual(cleared);
+  });
+});
+
+describe('fillOnly', () => {
+  const merge = fillOnly<string | null>();
+
+  it.each([null, undefined, ''])(
+    'fills when the stored value is %p',
+    (empty) => {
+      expect(merge(empty as string | null, 'claimed')).toBe('claimed');
+    },
+  );
+
+  it('never overwrites an owner that is already set', () => {
+    expect(merge('original', 'usurper')).toBe('original');
+  });
+});
+
+describe('keepHighest', () => {
+  const merge = keepHighest();
+
+  it('takes the larger value', () => {
+    expect(merge(40, 55)).toBe(55);
+  });
+
+  /**
+   * The Temple-outage fix: a null response used to be mapped to 0 and written
+   * straight over a real count.
+   */
+  it('refuses to lower a count, including to zero', () => {
+    expect(merge(42, 0)).toBe(42);
+    expect(merge(42, 41)).toBe(42);
+  });
+});
+
+describe('keepTrue', () => {
+  const merge = keepTrue();
+
+  it('latches on', () => {
+    expect(merge(false, true)).toBe(true);
+  });
+
+  /**
+   * A source reporting false is saying "I cannot see this", not "they don't
+   * have it". A false claim is caught by the moderator diff at submission.
+   */
+  it('never unsets a claim', () => {
+    expect(merge(true, false)).toBe(true);
+  });
+});
+
+describe('keepHighestOrdinal', () => {
+  const merge = keepHighestOrdinal(['None', 'Fire cape', 'Infernal cape']);
+
+  it('promotes to a higher rank', () => {
+    expect(merge('Fire cape', 'Infernal cape')).toBe('Infernal cape');
+  });
+
+  it('refuses to demote', () => {
+    expect(merge('Infernal cape', 'Fire cape')).toBe('Infernal cape');
+    expect(merge('Infernal cape', 'None')).toBe('Infernal cape');
+  });
+
+  it('keeps equal values stable', () => {
+    expect(merge('Fire cape', 'Fire cape')).toBe('Fire cape');
+  });
+
+  /**
+   * An unranked stored value should still yield to something recognised,
+   * rather than pinning the column forever.
+   */
+  it('treats a value outside the ranking as lowest', () => {
+    expect(merge('Nonsense cape', 'Fire cape')).toBe('Fire cape');
+    expect(merge('Fire cape', 'Nonsense cape')).toBe('Fire cape');
+  });
+});
+
+describe('preferResolved', () => {
+  const merge = preferResolved<string>();
+
+  it('takes a resolution', () => {
+    expect(merge(null, 'ironman')).toBe('ironman');
+    expect(merge('ironman', 'hardcore_ironman')).toBe('hardcore_ironman');
+  });
+
+  /**
+   * Temple reports null both for a real main and for a group ironman it has
+   * never heard of, so null is the absence of an answer — it must never erase
+   * an answer already given.
+   */
+  it('never erases a stored answer with null', () => {
+    expect(merge('group_ironman', null)).toBe('group_ironman');
+  });
+
+  it('leaves an unresolved account unresolved', () => {
+    expect(merge(null, null)).toBeNull();
+  });
+});

--- a/apps/web/lib/player-state/merge.ts
+++ b/apps/web/lib/player-state/merge.ts
@@ -1,0 +1,146 @@
+/**
+ * How a single stored value and a single incoming value combine.
+ *
+ * Every rule is pure, total, and obeys one convention that the whole design
+ * rests on:
+ *
+ * > **`undefined` means "unknown", never `false` and never `0`.**
+ *
+ * A patch omits what its author could not establish. A WikiSync outage does not
+ * report "no blood torva" — it reports nothing at all, and a rule that receives
+ * `undefined` must leave the stored value alone. Getting this wrong is what
+ * silently unset members' blood torva and zeroed their clue counts: the old
+ * write path mapped a missing source to `false`/`0` and then wrote it.
+ *
+ * `null`, `false`, `0` and `''` are *values*. Only `undefined` is absence.
+ */
+export type MergeRule<T> = (stored: T, incoming: T | undefined) => T;
+
+/** Null, undefined and empty string all count as "no value stored yet". */
+function isAbsent(value: unknown): boolean {
+  return value === null || value === undefined || value === '';
+}
+
+/**
+ * The value never changes once the row exists. Renames and other structural
+ * moves happen outside the patch system, in their own transactions.
+ */
+export function immutable<T>(): MergeRule<T> {
+  return (stored) => stored;
+}
+
+/**
+ * The write path owns this column outright — a patch can never set it. Used for
+ * bookkeeping like `updatedAt`, and for derived columns, which are recomputed
+ * after the merge rather than supplied.
+ */
+export function managed<T>(): MergeRule<T> {
+  return (stored) => stored;
+}
+
+/**
+ * Recomputed from other fields after every merge. Identical in behaviour to
+ * `managed`, named separately because it documents *why* the patch is ignored:
+ * the value is a function of other columns, so accepting it as input would let
+ * a caller assert something the data contradicts.
+ */
+export function recomputed<T>(): MergeRule<T> {
+  return (stored) => stored;
+}
+
+/**
+ * Take the incoming value whenever one was supplied.
+ *
+ * For columns where the source is authoritative and a value may legitimately go
+ * **down** — Temple periodically recalculates EHB/EHP rates, and bonus points
+ * fall when a Discord role is removed.
+ */
+export function preferFresh<T>(): MergeRule<T> {
+  // NOT `incoming ?? stored`: `??` also swallows null, and null is a value here
+  // rather than an absence. Only `undefined` means the source said nothing.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  return (stored, incoming) => (incoming === undefined ? stored : incoming);
+}
+
+/**
+ * Take the incoming value whenever one was supplied.
+ *
+ * Behaviourally identical to {@link preferFresh}, kept separate because it
+ * means something different: this column belongs to the player, and they must
+ * be able to set it back to nothing. `null`, `false` and `''` are all real
+ * choices here — which is precisely what the old `if (proofLink)` guard got
+ * wrong, making a proof link impossible to clear once set.
+ */
+export function replace<T>(): MergeRule<T> {
+  // NOT `incoming ?? stored` — that is the proof-link bug in a different
+  // spelling. Clearing a field to null is exactly what this rule must allow.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  return (stored, incoming) => (incoming === undefined ? stored : incoming);
+}
+
+/**
+ * Only fill a gap; never overwrite something already there. Used for the
+ * Discord id, which is claimed once and then belongs to that account.
+ */
+export function fillOnly<T>(): MergeRule<T> {
+  return (stored, incoming) =>
+    isAbsent(stored) && incoming !== undefined ? incoming : stored;
+}
+
+/**
+ * Keep whichever number is larger.
+ *
+ * These columns only ever go up in the game, so a smaller incoming value means
+ * the source is incomplete rather than that the player regressed. This is the
+ * rule that stops a Temple hiccup zeroing someone's clue counts.
+ */
+export function keepHighest(): MergeRule<number> {
+  return (stored, incoming) =>
+    incoming === undefined ? stored : Math.max(stored, incoming);
+}
+
+/**
+ * Once true, stays true.
+ *
+ * The player owns the claim and a source can only ever confirm it. A source
+ * that has gone quiet reports `undefined`; one that reports `false` is saying
+ * "I cannot see this", not "they don't have it". A false claim is caught by the
+ * moderator diff at submission, not by silently overwriting the player.
+ */
+export function keepTrue(): MergeRule<boolean> {
+  return (stored, incoming) => stored || (incoming ?? false);
+}
+
+/**
+ * Keep whichever value sits higher in an explicit ranking — the ordered
+ * equivalent of {@link keepHighest}, for tiers and capes.
+ *
+ * The ranking is passed in rather than read off the zod enum's declaration
+ * order, so reordering an enum for readability cannot silently change which
+ * value wins. A value missing from the ranking is treated as lowest, so an
+ * unrecognised stored value still yields to a recognised incoming one.
+ */
+export function keepHighestOrdinal<T>(ranking: readonly T[]): MergeRule<T> {
+  return (stored, incoming) => {
+    if (incoming === undefined) return stored;
+
+    return ranking.indexOf(incoming) > ranking.indexOf(stored)
+      ? incoming
+      : stored;
+  };
+}
+
+/**
+ * A non-null incoming value wins; null leaves the stored value alone.
+ *
+ * For account type, where null is not a value but the *absence of an answer* —
+ * `resolveTempleAccountType` returns null both for a real main and for a group
+ * ironman Temple has never heard of. A resolution that says nothing must not
+ * erase one that said something.
+ */
+export function preferResolved<T>(): MergeRule<T | null> {
+  // The one rule where `??` is genuinely the right operator: null and undefined
+  // mean the same thing here — nobody could establish an answer — and neither
+  // may erase a stored one. Contrast `replace` above, where null is a value.
+  return (stored, incoming) => incoming ?? stored;
+}


### PR DESCRIPTION
<!-- member-summary:start -->
Infrastructure work to make your stats more reliable — the site will stop occasionally forgetting things like your blood torva or clue scroll counts when a data source has a wobble.
<!-- member-summary:end -->

Second in the stack. **Pure groundwork — nothing imports this yet, so there is no runtime change and nothing can break.** The next PR wires it up.

## The problem it solves

No file currently says who is allowed to write which column on `players`. So every write path re-derives the answer, and they disagree with each other — and the disagreements are the bugs:

- A batch refresh overwrites a member's blood torva with `false`, because nothing says the player owns that claim and WikiSync had gone quiet.
- A Temple hiccup zeroes their clue counts, for the same reason — a null response is mapped to `0` and written.
- A special-case object (`currentDbValues`) exists in `fetch-player-details` to protect exactly *one* field, `hasRadiantOathplate`, that somebody once noticed.

`field-ownership.ts` states it once, for all 35 columns: an owner and a merge rule.

| Owner | Meaning |
|---|---|
| `identity` | Fixed at creation, or moved only by the rename transaction |
| `source` | Third-party data — Temple, WikiSync, hiscores, Discord |
| `contested` | Both a source and the player may write; the merge rule arbitrates |
| `player` | The player's own claim, which nothing can confirm or deny |
| `derived` | A function of other columns; never accepted as input |
| `staff` | Granted by approval or an admin, never by the calculator |
| `system` | Bookkeeping the write path maintains itself |

## The one idea underneath it

> **`undefined` means unknown — never `false`, never `0`.**

A patch omits what its author could not establish. A WikiSync outage does not report "no blood torva", it reports *nothing*, and a rule receiving `undefined` leaves the stored value alone. The old write path mapped a missing source to a falsy value and then wrote it. That is the entire bug class in one sentence.

`null`, `false`, `0` and `''` remain real values — which matters, because clearing a proof link has to be possible.

## The combinators

Each pure, total, and separately spec'd:

- **`keepHighest`** — clue counts and levels only go up in game, so a lower reading means an incomplete source, not a regression.
- **`keepTrue`** — a source reporting `false` is saying "I cannot see this", not "they don't have it". A *false claim* is caught by the moderator diff at submission, which is the right place for it.
- **`replace`** — must permit `null` / `false` / `''`. This is the proof-link fix: `if (proofLink)` meant a link could be set but never cleared.
- **`preferResolved`** — a null account type is the *absence of an answer* (Temple reports null for a real main and for a group ironman it has never heard of alike), so it must not erase one already given.
- **`keepHighestOrdinal`** — ranks by an **explicit list**, not the zod enum's declaration order. Reordering an enum for readability must not silently change which cape beats which — and `TzHaarCape`'s order is a by-product of `CollectionLogItemName.extract()`, which is no basis for a merge rule.

## Enforcement is a test, not a type

The mapped type says the table is exhaustive at compile time, but a type error is one `as` away from being silenced. The spec checks `Object.keys(fieldOwnership)` against `getTableColumns(players)` **at runtime**, so adding a column to `schema.ts` fails the suite until someone decides who owns it.

**I verified this rather than assuming it** — added a `canaryColumn` to `schema.ts`, watched `classifies every column, and invents none` fail, then reverted.

## Heads-up for the stack

This will make the accomplishments PR (#82) fail this spec when it rebases, because it adds `accomplishments_backfilled_at`. That is the guard doing its job — the column gets classified as `system` at that point.

## Tested

- **56 specs**, all passing: every combinator in isolation, the exhaustiveness check, write-permission rules (a player can't write `ehb`, `rank` or `staffRole`; a source can't write `proofLink`), and the named regressions — a quiet source can't unset blood torva or zero a clue count.
- Both typecheck projects clean; the four pre-existing `submit-rank-calculator.spec.ts` errors are unchanged.
- Full Jest suite diffed against `main`: **only additions**, the two new suites. Nothing else moved.
- eslint and prettier clean.

One lint note worth a glance: `@typescript-eslint/prefer-nullish-coalescing` wants `incoming ?? stored` in `preferFresh` and `replace`. That would be wrong — `??` also swallows `null`, and `null` is a value there, not an absence. Those two carry a disable with the reason inline. `preferResolved` genuinely *is* `??`, and uses it.

**Not verified:** nothing runs against a database, by design — this PR is pure functions and a table. The rules are only exercised by their specs until the next PR calls them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)