### PR TITLE
Stop a quiet data source wiping stats it cannot see

### DIFF
--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
@@ -43,8 +43,10 @@ import {
   TempleOSRSCollectionLogItem,
 } from '@/app/schemas/temple-api';
 
-export interface PlayerDetailsResponse
-  extends Omit<RankCalculatorSchema, 'rank' | 'points'> {
+export interface PlayerDetailsResponse extends Omit<
+  RankCalculatorSchema,
+  'rank' | 'points'
+> {
   currentRank?: Rank;
   hasTemplePlayerStats: boolean;
   hasTempleCollectionLog: boolean;
@@ -154,12 +156,31 @@ export async function fetchPlayerDetails(
         )
       : undefined;
 
-    // Always preserve manual checkbox values from database regardless of mergeSavedData
-    const currentDbValues = !mergeSavedData
-      ? {
-          hasRadiantOathplate: playerRecord.hasRadiantOathplate,
-        }
-      : undefined;
+    // The stored record is the floor for anything a source might fail to
+    // report. An unreachable source says *nothing*, which is not the same as
+    // saying "no" — but the values below are all computed as plain booleans and
+    // counts, so a missing source arrives here indistinguishable from a genuine
+    // negative and would be written straight over a real value.
+    //
+    // This used to cover `hasRadiantOathplate` alone (the one field somebody
+    // noticed, because it has no source at all) and only when `mergeSavedData`
+    // was false. Every field here has the same failure mode, and it applies in
+    // both modes: a player with no draft yet gets no protection from `savedData`
+    // either. Hence unconditional, and covering all of them.
+    const currentDbValues = {
+      hasRadiantOathplate: playerRecord.hasRadiantOathplate,
+      hasBloodTorva: playerRecord.hasBloodTorva,
+      hasDizanasQuiver: playerRecord.hasDizanasQuiver,
+      hasAchievementDiaryCape: playerRecord.hasAchievementDiaryCape,
+      clueScrollCounts: {
+        Beginner: playerRecord.clueCountBeginner,
+        Easy: playerRecord.clueCountEasy,
+        Medium: playerRecord.clueCountMedium,
+        Hard: playerRecord.clueCountHard,
+        Elite: playerRecord.clueCountElite,
+        Master: playerRecord.clueCountMaster,
+      },
+    };
 
     const { joinDate, playerName: rsn, rank: currentRank } = playerRecord;
     const [wikiSyncData, templePlayerStats, templeCollectionLog, discordRoles] =
@@ -340,11 +361,9 @@ export async function fetchPlayerDetails(
     const accountType = templeAccountType ?? playerRecord.accountType;
 
     if (templeAccountType && templeAccountType !== playerRecord.accountType) {
-      await updatePlayerAccountType(rsn, templeAccountType).catch(
-        (error) => {
-          Sentry.captureException(error);
-        },
-      );
+      await updatePlayerAccountType(rsn, templeAccountType).catch((error) => {
+        Sentry.captureException(error);
+      });
     }
 
     const result = {
@@ -379,16 +398,24 @@ export async function fetchPlayerDetails(
         proofLink,
         currentRank: currentRank as Rank,
         tzhaarCape: mergeTzhaarCapes(tzhaarCape, savedData?.tzhaarCape),
-        hasBloodTorva: (hasBloodTorva || savedData?.hasBloodTorva) ?? false,
+        // Each of these latches on: once earned it cannot be lost in game, so
+        // the only thing a `false` from any one input can mean is "this input
+        // could not see it". Falling through to the stored value last is what
+        // stops a WikiSync outage silently unsetting a member's kit.
+        hasBloodTorva:
+          hasBloodTorva ||
+          (savedData?.hasBloodTorva ?? false) ||
+          currentDbValues.hasBloodTorva,
         hasRadiantOathplate:
-          savedData?.hasRadiantOathplate ??
-          currentDbValues?.hasRadiantOathplate ??
-          false,
+          savedData?.hasRadiantOathplate ?? currentDbValues.hasRadiantOathplate,
         hasDizanasQuiver:
-          (hasDizanasQuiver || savedData?.hasDizanasQuiver) ?? false,
+          hasDizanasQuiver ||
+          (savedData?.hasDizanasQuiver ?? false) ||
+          currentDbValues.hasDizanasQuiver,
         hasAchievementDiaryCape:
-          (hasAchievementDiaryCape || savedData?.hasAchievementDiaryCape) ??
-          false,
+          hasAchievementDiaryCape ||
+          (savedData?.hasAchievementDiaryCape ?? false) ||
+          currentDbValues.hasAchievementDiaryCape,
         hasTemplePlayerStats: !!templePlayerStats,
         hasTempleCollectionLog: !!templeCollectionLog,
         hasWikiSyncData: !!wikiSyncData,
@@ -400,13 +427,35 @@ export async function fetchPlayerDetails(
         combatBonusPoints,
         skillingBonusPoints: 0, // Leaving this in for future use, if we decide to add a skilling diary
         notableItemsBonusPoints: 0, // Leaving this in for future use, if we decide to add a notable items diary
+        // Clue counts only go up in game, so a reading lower than what is
+        // stored means Temple is incomplete rather than that the player lost
+        // clues. Without the floor, a Temple outage maps every count to 0 and
+        // writes it, wiping the lot.
         clueScrollCounts: {
-          Beginner: beginnerClueCount ?? 0,
-          Easy: easyClueCount ?? 0,
-          Medium: mediumClueCount ?? 0,
-          Hard: hardClueCount ?? 0,
-          Elite: eliteClueCount ?? 0,
-          Master: masterClueCount ?? 0,
+          Beginner: Math.max(
+            beginnerClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Beginner,
+          ),
+          Easy: Math.max(
+            easyClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Easy,
+          ),
+          Medium: Math.max(
+            mediumClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Medium,
+          ),
+          Hard: Math.max(
+            hardClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Hard,
+          ),
+          Elite: Math.max(
+            eliteClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Elite,
+          ),
+          Master: Math.max(
+            masterClueCount ?? 0,
+            currentDbValues.clueScrollCounts.Master,
+          ),
         },
         rawCollectionLogItems: templeCollectionLog
           ? templeCollectionLog.items

--- a/apps/web/lib/db/player-operations.ts
+++ b/apps/web/lib/db/player-operations.ts
@@ -179,7 +179,8 @@ export interface UpdatePlayerData {
   ehp?: number;
   combatAchievementTier?: string;
   rank?: string;
-  proofLink?: string;
+  // Nullable, matching the column: null clears the link, undefined leaves it.
+  proofLink?: string | null;
   collectionLogCount?: number;
   collectionLogTotal?: number;
   totalLevel?: number;
@@ -686,7 +687,10 @@ export async function updatePlayerWithFullData(
   if (ehp !== undefined && ehp !== null) updateData.ehp = ehp;
   if (combatAchievementTier && combatAchievementTier !== 'None')
     updateData.combatAchievementTier = combatAchievementTier;
-  if (proofLink) updateData.proofLink = proofLink;
+  // `undefined` means the caller had nothing to say; `null` and `''` are the
+  // player deliberately removing their link. `if (proofLink)` conflated the
+  // three and made a proof link impossible to clear once set.
+  if (proofLink !== undefined) updateData.proofLink = proofLink;
   if (collectionLogCount !== undefined && collectionLogCount !== null)
     updateData.collectionLogCount = collectionLogCount;
   if (collectionLogTotal !== undefined && collectionLogTotal !== null)


### PR DESCRIPTION
<!-- member-summary:start -->
Fixed a bug where the site could forget things it already knew about you — your blood torva, Dizana's quiver, diary cape or clue scroll counts could be silently cleared whenever a stats provider had an outage. You can also now remove a proof link once you've added one.
<!-- member-summary:end -->

Replaces #85, which is closed. Three real bugs, fixed where they occur.

## The shape of all three

A source that is unreachable reports **nothing**. That nothing gets computed into a `false` or a `0`, and the result is written straight over a real value.

| Field | Source | What happens when it's down |
|---|---|---|
| `hasBloodTorva` | WikiSync CAs 490/499/508/517 | `wikiSyncData` is null → `false` → overwrites `true` |
| `hasDizanasQuiver` | WikiSync CA 538 | same |
| `hasAchievementDiaryCape` | derived from diaries | same |
| `clueCount*` (×6) | TempleOSRS | null response → `?? 0` → overwrites the real count |

`updatePlayerWithFullData` guards those booleans with `!== undefined` only, so `false` is a legitimate value to write. **The batch refresh runs with `mergeSavedData: false`**, which is precisely the mode with no draft to fall back on — so an outage during a nightly run unsets kit across the whole clan at once.

## The fix

A preservation object already existed for exactly this reason. It covered **one field** — `hasRadiantOathplate`, the one somebody noticed, because it has no data source at all — and only when `mergeSavedData` was false.

It now covers every field with the same failure mode, unconditionally. The `!mergeSavedData` condition was itself a gap: a player with no draft yet gets no protection from `savedData` either.

Two merge rules, chosen to match the game rather than the code:

- **The booleans latch on.** None of them can be lost in game, so the only thing a `false` from any single input can mean is "this input could not see it".
- **Clue counts take the stored value as a floor.** They only ever go up, so a lower reading means Temple is incomplete, not that the player lost clues.

A genuinely false claim is still caught where it should be — the moderator diff at submission — rather than by silently overwriting the player.

## Also: the proof link could never be cleared

`if (proofLink)` conflated "the caller had nothing to say" with "the player deliberately removed their link". It now checks `!== undefined`, and `UpdatePlayerData.proofLink` is widened to `string | null` to match the nullable column.

## Why this and not #85

#85 built a full field-ownership model — an owner and a merge rule for all 35 columns, with a runtime exhaustiveness check. It was closed after an honest accounting: ~393 lines of non-test code (net ~160 after replacing the hand-written guards) to fix bugs that need about ten lines between them, plus a permission matrix nothing called yet. Two contributors and a schema that changes twice a year isn't the coordination problem an ownership table solves.

The merge *semantics* it encoded survive as the comments above, where they apply.

## Tested

- Both typecheck projects clean; the four pre-existing `submit-rank-calculator.spec.ts` errors unchanged.
- Full Jest suite diffed against `main`: **identical**, suite for suite.
- eslint and prettier clean.

**Not verified, and worth being clear about:** none of this is covered by a test. The logic lives inside `fetchPlayerDetails`, a 433-line function that makes four network calls and writes to the database, and its spec file is 1,100 lines of entirely commented-out tests. The fixes were verified by reading the data flow, not by exercising it.

Reproducing the original bug needs WikiSync or Temple to be down (or stubbed) during a batch run, which can't be done headlessly against the real thing. The read/sync split later in the stack is what makes this code testable — at which point these three cases are the first specs worth writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)