### PR TITLE
Give notable-item ticks a home outside the Redis draft

### DIFF
--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
@@ -39,6 +39,10 @@ import {
   updatePlayerAccountType,
 } from '@/lib/db/player-operations';
 import {
+  getItemOverrides,
+  syncItemOverrides,
+} from '@/lib/db/item-override-operations';
+import {
   resolveTempleAccountType,
   TempleOSRSCollectionLogItem,
 } from '@/app/schemas/temple-api';
@@ -279,11 +283,18 @@ export async function fetchPlayerDetails(
             .map(({ name }) => stripEntityName(name))
         : [];
 
-    const previouslyAcquiredItems = savedData
-      ? Object.keys(savedData.acquiredItems).filter(
-          (key) => savedData.acquiredItems[key],
-        )
-      : [];
+    // What the player has said for themselves, from both places it can live.
+    //
+    // The draft still wins where it has an opinion, so nothing changes for a
+    // player mid-edit. The stored overrides are what make that draft removable:
+    // they are the only durable home for a tick no data source accounts for,
+    // and they are written back further down.
+    const storedOverrides = await getItemOverrides(playerRecord.playerName);
+
+    const previouslyAcquiredItems = Object.keys({
+      ...storedOverrides,
+      ...(savedData?.acquiredItems ?? {}),
+    }).filter((key) => savedData?.acquiredItems?.[key] ?? storedOverrides[key]);
 
     const allCurrentNotableItemNames = new Set(
       Object.values(itemList)
@@ -470,6 +481,23 @@ export async function fetchPlayerDetails(
       } catch (error) {
         console.error('Failed to sync player data to database:', error);
         // Continue even if database sync fails
+      }
+
+      // Persist the ticks the sources don't account for. This has to happen
+      // here rather than inside `processPlayerData`, because this is the only
+      // place that still knows which items were *derived* — by the time the
+      // response is assembled the two sets have been unioned and the
+      // distinction is gone.
+      //
+      // After `processPlayerData`, so a brand new player has a row to hang
+      // these off. Non-fatal for the same reason as the sync above.
+      try {
+        await syncItemOverrides(playerRecord.playerName, {
+          derived: acquiredItems,
+          submitted: acquiredItemsMap,
+        });
+      } catch (error) {
+        console.error('Failed to sync notable item overrides:', error);
       }
     }
 

--- a/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
+++ b/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
@@ -18,6 +18,7 @@ import {
   playerAchievementDiaries,
   playerRankUps,
   playerAccomplishments,
+  playerItemOverrides,
 } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
@@ -66,9 +67,11 @@ export const editPlayerAction = authActionClient
       // that on both — so an unresolvable account is cleared to null instead,
       // and the calculator asks its owner.
       const renamedAccountType = hasPlayerNameChanged
-        ? await resolveAccountType(maybeFormattedPlayerName, tracking.info).then(
-            (resolution) =>
-              resolution.status === 'resolved' ? resolution.accountType : null,
+        ? await resolveAccountType(
+            maybeFormattedPlayerName,
+            tracking.info,
+          ).then((resolution) =>
+            resolution.status === 'resolved' ? resolution.accountType : null,
           )
         : undefined;
 
@@ -111,6 +114,14 @@ export const editPlayerAction = authActionClient
             .update(playerAccomplishments)
             .set({ playerName: maybeFormattedPlayerName })
             .where(eq(playerAccomplishments.playerName, previousPlayerName));
+
+          // Overrides are keyed by player name too, and are the only home for
+          // a tick no data source explains — stranding them would silently
+          // undo the player's own answers.
+          await tx
+            .update(playerItemOverrides)
+            .set({ playerName: maybeFormattedPlayerName })
+            .where(eq(playerItemOverrides.playerName, previousPlayerName));
         });
       } else {
         // No name change, just update the player record

--- a/apps/web/drizzle/0020_smart_arclight.sql
+++ b/apps/web/drizzle/0020_smart_arclight.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "player_item_overrides" (
+	"player_name" varchar(12) NOT NULL,
+	"item_name" text NOT NULL,
+	"is_acquired" boolean NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "player_item_overrides_player_name_item_name_pk" PRIMARY KEY("player_name","item_name")
+);

--- a/apps/web/drizzle/meta/0020_snapshot.json
+++ b/apps/web/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,779 @@
+{
+  "id": "4e7a9852-92e5-429d-aaeb-d7851fc4342f",
+  "prevId": "fce4c64d-2f63-4903-bcd6-37f164c765fc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.player_accomplishments": {
+      "name": "player_accomplishments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "accomplishment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accomplishment_key": {
+          "name": "accomplishment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_item_name": {
+          "name": "icon_item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_backfilled": {
+          "name": "is_backfilled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_accomplishments_achieved_at_idx": {
+          "name": "player_accomplishments_achieved_at_idx",
+          "columns": [
+            {
+              "expression": "achieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_accomplishments_player_name_accomplishment_key_unique": {
+          "name": "player_accomplishments_player_name_accomplishment_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "accomplishment_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_achievement_diaries": {
+      "name": "player_achievement_diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_acquired_items": {
+      "name": "player_acquired_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_category": {
+          "name": "item_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_first_logged": {
+          "name": "date_first_logged",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_acquired_items_item_id_idx": {
+          "name": "player_acquired_items_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_acquired_items_player_name_item_id_unique": {
+          "name": "player_acquired_items_player_name_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_item_overrides": {
+      "name": "player_item_overrides",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_acquired": {
+          "name": "is_acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_item_overrides_player_name_item_name_pk": {
+          "name": "player_item_overrides_player_name_item_name_pk",
+          "columns": [
+            "player_name",
+            "item_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_rank_ups": {
+      "name": "player_rank_ups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "old_rank": {
+          "name": "old_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_rank": {
+          "name": "new_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ehb": {
+          "name": "ehb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ehp": {
+          "name": "ehp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_achievement_tier": {
+          "name": "combat_achievement_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_link": {
+          "name": "proof_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_log_count": {
+          "name": "collection_log_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_total": {
+          "name": "collection_log_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_level": {
+          "name": "total_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1154
+        },
+        "clue_count_beginner": {
+          "name": "clue_count_beginner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_easy": {
+          "name": "clue_count_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_medium": {
+          "name": "clue_count_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_hard": {
+          "name": "clue_count_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_elite": {
+          "name": "clue_count_elite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_master": {
+          "name": "clue_count_master",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tzhaar_cape": {
+          "name": "tzhaar_cape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "has_blood_torva": {
+          "name": "has_blood_torva",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_radiant_oathplate": {
+          "name": "has_radiant_oathplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dizanas_quiver": {
+          "name": "has_dizanas_quiver",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_achievement_diary_cape": {
+          "name": "has_achievement_diary_cape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "combat_bonus_points": {
+          "name": "combat_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skilling_bonus_points": {
+          "name": "skilling_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_bonus_points": {
+          "name": "collection_log_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notable_items_bonus_points": {
+          "name": "notable_items_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile_only": {
+          "name": "is_mobile_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gim_group_name": {
+          "name": "gim_group_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "accomplishments_backfilled_at": {
+          "name": "accomplishments_backfilled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_player_name_lower_unique": {
+          "name": "players_player_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"player_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_role_changes": {
+      "name": "staff_role_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_role": {
+          "name": "old_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_role": {
+          "name": "new_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_player_name": {
+          "name": "changed_by_player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_discord_user_id": {
+          "name": "changed_by_discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_role_changes_player_name_idx": {
+          "name": "staff_role_changes_player_name_idx",
+          "columns": [
+            {
+              "expression": "player_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.accomplishment_type": {
+      "name": "accomplishment_type",
+      "schema": "public",
+      "values": [
+        "collection_log",
+        "total_level",
+        "ehb",
+        "ehp",
+        "maxed",
+        "elite_diary",
+        "diary_cape",
+        "combat_achievement",
+        "inferno",
+        "colosseum",
+        "blood_torva",
+        "radiant_oathplate",
+        "toa_cursed_phalanx",
+        "pet"
+      ]
+    },
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "main",
+        "ironman",
+        "hardcore_ironman",
+        "ultimate_ironman",
+        "group_ironman",
+        "hardcore_group_ironman",
+        "unranked_group_ironman"
+      ]
+    },
+    "public.staff_role": {
+      "name": "staff_role",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "admin",
+        "deputy_owner",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1787301762382,
       "tag": "0019_third_yellow_claw",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1787334045753,
+      "tag": "0020_smart_arclight",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/item-override-operations.spec.ts
+++ b/apps/web/lib/db/item-override-operations.spec.ts
@@ -1,0 +1,85 @@
+import { diffItemOverrides } from './item-override-operations';
+
+describe('diffItemOverrides', () => {
+  it('stores a claim no source accounts for', () => {
+    expect(
+      diffItemOverrides({
+        derived: [],
+        submitted: { 'Dragon defender': true },
+      }),
+    ).toEqual([{ itemName: 'Dragon defender', isAcquired: true }]);
+  });
+
+  /**
+   * Not simply a list of claimed items: unticking something a source *does*
+   * report is also an answer, and has to survive the next sync.
+   */
+  it('stores an explicit untick of something a source reports', () => {
+    expect(
+      diffItemOverrides({
+        derived: ['Abyssal whip'],
+        submitted: {},
+      }),
+    ).toEqual([{ itemName: 'Abyssal whip', isAcquired: false }]);
+  });
+
+  it('stores nothing when the sources already agree', () => {
+    expect(
+      diffItemOverrides({
+        derived: ['Abyssal whip'],
+        submitted: { 'Abyssal whip': true },
+      }),
+    ).toEqual([]);
+  });
+
+  it('stores nothing for an item nobody mentions', () => {
+    expect(diffItemOverrides({ derived: [], submitted: {} })).toEqual([]);
+  });
+
+  /**
+   * The self-healing property, and the reason the table stays small: once
+   * Temple catches up on a claimed item, the disagreement disappears and the
+   * row goes with it — which also shrinks the moderator's submission diff
+   * without anyone doing anything.
+   */
+  it('drops a claim once a source catches up with it', () => {
+    const claimed = { 'Tumeken’s guardian': true };
+
+    expect(diffItemOverrides({ derived: [], submitted: claimed })).toHaveLength(
+      1,
+    );
+    expect(
+      diffItemOverrides({
+        derived: ['Tumeken’s guardian'],
+        submitted: claimed,
+      }),
+    ).toEqual([]);
+  });
+
+  it('handles a mixed sheet', () => {
+    const overrides = diffItemOverrides({
+      derived: ['Abyssal whip', 'Bandos chestplate'],
+      submitted: { 'Abyssal whip': true, 'Dragon defender': true },
+    });
+
+    expect(overrides).toEqual(
+      expect.arrayContaining([
+        // Claimed, unexplained.
+        { itemName: 'Dragon defender', isAcquired: true },
+        // Reported by a source, unticked by the player.
+        { itemName: 'Bandos chestplate', isAcquired: false },
+      ]),
+    );
+    // 'Abyssal whip' is agreed on, so it is not stored.
+    expect(overrides).toHaveLength(2);
+  });
+
+  it('is stable when run twice over the same sheet', () => {
+    const input = {
+      derived: ['Abyssal whip'],
+      submitted: { 'Dragon defender': true },
+    };
+
+    expect(diffItemOverrides(input)).toEqual(diffItemOverrides(input));
+  });
+});

--- a/apps/web/lib/db/item-override-operations.ts
+++ b/apps/web/lib/db/item-override-operations.ts
@@ -1,0 +1,106 @@
+import { eq } from 'drizzle-orm';
+import { db } from './index';
+import { playerItemOverrides } from './schema';
+
+export interface ItemOverrideSync {
+  /** Items the data sources account for on their own. */
+  derived: Iterable<string>;
+  /** What the player's sheet actually says, keyed the way the form keys it. */
+  submitted: Record<string, boolean>;
+}
+
+/**
+ * Splits a player's answers into the ones the sources already explain and the
+ * ones only the player is asserting.
+ *
+ * Pure, so the rule is testable without a database. An override is stored only
+ * where the two disagree:
+ *
+ * | derived | submitted | meaning                    | stored |
+ * |---------|-----------|----------------------------|--------|
+ * | no      | yes       | a claim nothing backs up   | `true` |
+ * | yes     | no        | an explicit untick         | `false`|
+ * | yes     | yes       | sources agree              | —      |
+ * | no      | no        | nothing to say             | —      |
+ *
+ * The two "—" rows are what makes this self-healing: when Temple catches up on
+ * a claimed item, the disagreement disappears and the row goes with it.
+ */
+export function diffItemOverrides({ derived, submitted }: ItemOverrideSync) {
+  const derivedSet = new Set(derived);
+  const overrides: { itemName: string; isAcquired: boolean }[] = [];
+
+  // A claim the sources do not account for.
+  Object.entries(submitted).forEach(([itemName, isAcquired]) => {
+    if (isAcquired && !derivedSet.has(itemName)) {
+      overrides.push({ itemName, isAcquired: true });
+    }
+  });
+
+  // An explicit untick of something a source *does* report. `submitted` only
+  // carries truthy keys once the schema's `pickBy` has run, so absence is the
+  // untick.
+  derivedSet.forEach((itemName) => {
+    if (!submitted[itemName]) {
+      overrides.push({ itemName, isAcquired: false });
+    }
+  });
+
+  return overrides;
+}
+
+/**
+ * Brings a player's stored overrides in line with their sheet.
+ *
+ * Replaces the whole set rather than patching it, because the set is small
+ * (most members override nothing) and a partial update would leave rows behind
+ * for items that have since been explained by a source — which is exactly the
+ * drift this table is meant not to accumulate.
+ */
+export async function syncItemOverrides(
+  playerName: string,
+  input: ItemOverrideSync,
+): Promise<number> {
+  const overrides = diffItemOverrides(input);
+
+  await db.transaction(async (tx) => {
+    // Delete-then-insert rather than a diffed upsert. The set is small — most
+    // members override nothing — and doing it wholesale is what guarantees no
+    // row survives for an item a source has since explained.
+    await tx
+      .delete(playerItemOverrides)
+      .where(eq(playerItemOverrides.playerName, playerName));
+
+    if (overrides.length > 0) {
+      await tx.insert(playerItemOverrides).values(
+        overrides.map(({ itemName, isAcquired }) => ({
+          playerName,
+          itemName,
+          isAcquired,
+        })),
+      );
+    }
+  });
+
+  return overrides.length;
+}
+
+/**
+ * A player's stored overrides, as the form keys them.
+ */
+export async function getItemOverrides(
+  playerName: string,
+): Promise<Record<string, boolean>> {
+  const rows = await db
+    .select({
+      itemName: playerItemOverrides.itemName,
+      isAcquired: playerItemOverrides.isAcquired,
+    })
+    .from(playerItemOverrides)
+    .where(eq(playerItemOverrides.playerName, playerName));
+
+  return rows.reduce<Record<string, boolean>>(
+    (acc, { itemName, isAcquired }) => ({ ...acc, [itemName]: isAcquired }),
+    {},
+  );
+}

--- a/apps/web/lib/db/player-operations.ts
+++ b/apps/web/lib/db/player-operations.ts
@@ -6,6 +6,7 @@ import {
   playerAchievementDiaries,
   playerRankUps,
   playerAccomplishments,
+  playerItemOverrides,
   type Player,
   type NewPlayer,
   type PlayerAcquiredItem,
@@ -139,6 +140,9 @@ export async function deletePlayer(
     await tx
       .delete(playerAccomplishments)
       .where(eq(playerAccomplishments.playerName, playerName));
+    await tx
+      .delete(playerItemOverrides)
+      .where(eq(playerItemOverrides.playerName, playerName));
 
     // Delete the player record
     await tx.delete(players).where(eq(players.playerName, playerName));

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -12,6 +12,7 @@ import {
   unique,
   uniqueIndex,
   index,
+  primaryKey,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm/sql/sql';
 import { relations } from 'drizzle-orm';
@@ -265,6 +266,69 @@ export const playerRankUpsRelations = relations(playerRankUps, ({ one }) => ({
     references: [players.playerName],
   }),
 }));
+
+/**
+ * Notable items a player has ticked that no data source accounts for.
+ *
+ * `player_acquired_items` holds what TempleOSRS reports from the collection
+ * log, and quest/combat-achievement items are derived live from WikiSync. What
+ * neither covers is the player reaching into the calculator and ticking
+ * something themselves — an item Temple has not caught up on, or one that is
+ * only evidenced by a screenshot. Until this table, that lived **only in the
+ * Redis draft**, which made the draft impossible to delete without losing it.
+ *
+ * **Sparse, not a materialised map.** A row exists only where the player's
+ * answer *differs* from what the sources derive. So:
+ *
+ *     effective = derived(collection log ∪ quests ∪ CAs) ⊕ overrides
+ *
+ * Three things fall out of that, all of them wanted:
+ *
+ * - It self-heals. When Temple catches up and the derived set agrees, the row
+ *   is deleted, and the moderator's submission diff shrinks by itself.
+ * - It stays correct as `data/item-list.ts` changes — which it does routinely,
+ *   via the `add-osrs-content` skill. A materialised map would accumulate rows
+ *   for items that no longer exist.
+ * - It *is* the discrepancy list. An override with `is_acquired = true` is
+ *   exactly "the player claims this and no source agrees", which is what the
+ *   submission diff already wants to show a moderator.
+ */
+export const playerItemOverrides = pgTable(
+  'player_item_overrides',
+  {
+    playerName: varchar('player_name', { length: 12 }).notNull(),
+    /**
+     * The form's own key for the item — `stripEntityName(item.name)`. Stored
+     * verbatim so it round-trips through the calculator without translation.
+     */
+    itemName: text('item_name').notNull(),
+    /**
+     * The player's answer. `false` is meaningful: it is an explicit untick of
+     * something a source *does* report, which is why this is not simply a list
+     * of claimed items.
+     */
+    isAcquired: boolean('is_acquired').notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    playerItemOverridePk: primaryKey({
+      columns: [table.playerName, table.itemName],
+    }),
+  }),
+);
+
+export type PlayerItemOverride = typeof playerItemOverrides.$inferSelect;
+export type NewPlayerItemOverride = typeof playerItemOverrides.$inferInsert;
+
+export const playerItemOverridesRelations = relations(
+  playerItemOverrides,
+  ({ one }) => ({
+    player: one(players, {
+      fields: [playerItemOverrides.playerName],
+      references: [players.playerName],
+    }),
+  }),
+);
 
 /**
  * Notable things a member has done, as a feed alongside rank ups and clogs.


### PR DESCRIPTION
<!-- member-summary:start -->
Infrastructure work so the notable items you tick yourself are stored properly — groundwork for the calculator saving your changes automatically.
<!-- member-summary:end -->

## The problem

`updatePlayerWithFullData` destructures `rawCollectionLogItems`, **never `acquiredItems`**. So:

- `player_acquired_items` ← what TempleOSRS reports from the collection log
- quest / combat-achievement items ← derived live from WikiSync
- **a player's own ticks ← the Redis draft key, and nowhere else**

This is the single thing that makes the draft impossible to delete. Removing it today would silently discard every manual tick in the clan — an item Temple hasn't caught up on, or one evidenced only by a screenshot.

## The design

`player_item_overrides` is **sparse**. A row exists only where the player's answer *differs* from what the sources derive:

```
effective = derived(collection log ∪ quests ∪ CAs) ⊕ overrides
```

| derived | submitted | meaning | stored |
|---|---|---|---|
| no | yes | a claim nothing backs up | `true` |
| yes | no | an explicit untick | `false` |
| yes | yes | sources agree | — |
| no | no | nothing to say | — |

Three properties fall out of the two blank rows, all of them wanted:

- **It self-heals.** When Temple catches up on a claimed item, the disagreement disappears and the row goes with it — which also shrinks the moderator's submission diff without anyone doing anything.
- **It stays correct as `data/item-list.ts` changes**, which it does routinely via the `add-osrs-content` skill. A materialised map would accumulate rows for items that no longer exist.
- **It *is* the discrepancy list.** An override with `is_acquired = true` is exactly "the player claims this and no source agrees" — which is what `RankSubmissionDiff.acquiredItems` already wants to show a moderator, currently computed with `pickBy` gymnastics at submit time.

`false` is meaningful and stored: unticking something a source *does* report is also an answer, so this isn't merely a list of claimed items.

## Where it's written, and why there

From `fetch-player-details`, not `processPlayerData` — **that's the only place that still knows which items were derived**. By the time the response is assembled, `acquiredItems` and `previouslyAcquiredItems` have been unioned and the distinction is gone.

Reading prefers the draft where it has an opinion, so **nothing changes for a player mid-edit**. The overrides are what will carry those answers once the draft is removed.

Also wired into `deletePlayer` and the rename transaction, alongside the other per-player tables — stranding overrides under an old name would silently undo a player's own answers.

## Tested

- 7 hermetic specs on `diffItemOverrides`, the pure rule: each cell of the table above, the self-healing case, a mixed sheet, and idempotence.
- Both typecheck projects clean.
- Full Jest suite diffed against the base: **only addition is the new passing suite**.
- eslint and prettier clean.

**Not verified:** nothing has run against a database. `syncItemOverrides` and `getItemOverrides` are only exercised through their types — the delete-then-insert transaction, the primary key and the read-back have not been executed. The calculator is Discord-auth-gated, so the round trip (tick an item → stored as an override → still ticked on reload) needs a browser login.

Migration `0020` is generated but **not run**. It follows `0019` from #82, so run that first if you haven't.

Worth knowing for review: **this PR is inert on its own.** It writes and reads a table nothing depends on yet — the draft is still authoritative. It becomes load-bearing only when the draft is deleted, which is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)