### PR TITLE
Rework the activity feeds: one accomplishment per sync, side-by-side columns, no duplicated clog rail

### DIFF
--- a/.github/workflows/announce-merge.yaml
+++ b/.github/workflows/announce-merge.yaml
@@ -36,7 +36,6 @@ jobs:
           # PR title or body execute shell commands on this runner.
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
           WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
         run: |
           set -euo pipefail
@@ -70,18 +69,18 @@ jobs:
           # jq builds the payload so quotes, newlines and backslashes in the
           # summary can't break out of the JSON.
           payload=$(
+            # No PR link and no PR number: this lands in a members' channel,
+            # where a GitHub URL is noise at best and an invitation to read a
+            # diff at worst. The summary is the whole message. `PR_NUMBER` is
+            # still used for the workflow's own logging above.
             jq -n \
               --arg description "$summary" \
-              --arg url "$PR_URL" \
-              --arg footer "Irons' Grotto · #${PR_NUMBER}" \
               '{
                 username: "Irons'"'"' Grotto",
                 embeds: [{
                   title: "Site update",
-                  url: $url,
                   description: $description,
-                  color: 3527322,
-                  footer: { text: $footer }
+                  color: 3527322
                 }]
               }'
           )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Clean, data-forward minimalism on the dark navy base (think Linear / Vercel / tr
 - **Green is a deliberate accent** — buttons, links, focus, active sort, small highlights only. Structure is **hairline** (`rgb(var(--ig-text-muted) / 0.1)`) borders + typography, not colored borders. Buttons are flat (solid green + dark `--ig-on-accent` text, or hairline ghost) — no gradient fills, lift, or glow.
 - **No emoji as UI**, no neon glow / floating / rotating-ray backgrounds. Headers use the `<SectionHeader>` primitive (`app/components/section-header.tsx`): display title + muted subtitle + muted radix-icon + actions slot.
 - **Reusable primitives:** `SectionHeader`; the activity-feed style (`app/components/activity-feed.module.css`) shared by the rank-ups + collection-log feeds (item/rank tile + two-line entry + count badge + mono time); the leaderboard's `leaderboard.module.css`.
-- **Infinite scroll everywhere — no "Load more" buttons.** Paginated lists auto-fetch near the scroll end (leaderboard `handleScroll`; clogs scroller `onLoadMore`).
+- **Infinite scroll everywhere — no "Load more" buttons.** Paginated lists auto-fetch near the scroll end (leaderboard `handleScroll`; `recent-clogs-scroller`'s `onLoadMore` is the other worked example, though that component is not currently rendered — see below).
 
 ## Clan data components
 
@@ -117,7 +117,7 @@ The DB stores far more than the leaderboard shows; these surface it (all in `app
 - **`PlayerProfileModal`** — opens over the current window when a player name is clicked. Fetches `GET /api/player-profile?name=` (→ `fetchPlayerProfile`): rank progress vs `rankThresholds`, stat grid, notable-item badges, clue tiers, achievement-diary matrix (`playerAchievementDiaries`, otherwise unused), and rank-up timeline.
 - **`RarestDrops`** ("Rarest in the Grotto") ← `fetchCollectionLogInsights` — items the fewest members have logged, from `playerAcquiredItems`.
 
-**Clickable player names, app-wide.** The profile modal is hosted once by `PlayerProfileProvider` (in `app/providers.tsx`). Render any clan member's name with `<PlayerNameButton name={rsn} .../>` (or call `usePlayerProfile().openProfile(name)`) and it opens their profile — used in the leaderboard, both activity feeds, the clogs scroller, and the inactivity checker. Prefer this over linking names out to TempleOSRS.
+**Clickable player names, app-wide.** The profile modal is hosted once by `PlayerProfileProvider` (in `app/providers.tsx`). Render any clan member's name with `<PlayerNameButton name={rsn} .../>` (or call `usePlayerProfile().openProfile(name)`) and it opens their profile — used in the leaderboard, the activity feeds, and the inactivity checker. Prefer this over linking names out to TempleOSRS.
 
 > **Design north-star:** the player profile modal (`player-profile-modal.tsx` + its module CSS) sets the layout/type/hairline/token patterns for the app. The **rank calculator was rebuilt against it** (see below) — match both when adding UI.
 
@@ -141,6 +141,12 @@ Three things to preserve when touching this page:
 - **Category inputs live in modals, so tests must open them first.** Jest specs click the tile and await the dialog; the Cypress helper `generateScalingTests` takes an `openCategory` regex for the same reason. Totals stay on the tile, so only per-input assertions need the modal.
 - **Nothing on the client writes points.** `useRank` / `useRankCalculator` / `useTotalPoints` are pure — the running total they produce is for display only, and `useTotalPoints` remains the cheaper option when just the number is needed. `players.points` is recalculated server-side by `calculatePlayerPoints` (`app/rank-calculator/utils/calculate-player-points.ts`) inside `processPlayerData`, from the stored record, and that is the only place it is written. Don't reintroduce a client-side write: the previous one posted to an **unauthenticated** action taking `(playerName, points)`, so the leaderboard was whatever the client last claimed, for whichever player it named. If `calculatePlayerPoints` throws (it needs live wiki drop rates) the stored total is left alone — stale is a cosmetic lag, zero would be a catastrophe.
 
+### Feeds on the homepage and dashboard
+
+Three activity feeds sit in one `auto-fit` grid (`minmax(320px, 1fr)`, gap 2rem) on both pages: **Rank Ups**, **Accomplishments**, **Collection Log**. Three across when there's room, collapsing to two then one with no breakpoint arithmetic. Grid's default `align-items: stretch` keeps the cards level, which the fixed `max-height: 420px` on `.list` in `activity-feed.module.css` already assumes. Accomplishments renders conditionally — with nothing to show it would leave an empty grid cell, and a column of whitespace reads worse than two columns.
+
+**"Your Latest Collection Logs" is deliberately not rendered.** `RecentClogsContainer` / `recent-clogs-scroller` / `fetchUserRecentClogs` / `GET /api/user-recent-clogs` all still exist and work — they were unmounted from the dashboard on member feedback, because showing someone their own recent clog items duplicates the collection log in game exactly. The clan-wide **Collection Log** feed is a different thing and stays: other members' drops aren't visible in game.
+
 Data-source convention: return `{ success: true, data } | { success: false, error }`; filter to `players.isActive`; `isMaxed = totalLevel === 2376`; pets = `playerAcquiredItems.itemId in AllPetItemIds`; infernal = `tzhaarCape === 'Infernal cape'`.
 
 ## Accomplishments feed
@@ -163,9 +169,11 @@ The third activity feed, alongside rank ups and collection log — the notable t
 
 A player crossing several thresholds at once earns **all** of them (1,100 clog slots → 100/250/500/750/1000), and Grandmaster CAs earn Master too. That is deliberate and follows from statelessness.
 
-⚠️ **The feed is capped per sync, not filtered by age.** Detection stamps everything found in one run with a single timestamp, so a member tracked for the first time — or syncing Temple after a long gap — lands a burst of rows sharing one `achieved_at`. `fetchRecentAccomplishments` shows at most `maxAccomplishmentsPerSync` (5) from any one `(player, achieved_at)` group.
+⚠️ **The feed shows at most one row per `(player, achieved_at)`.** Detection stamps everything found in one run with a single timestamp, so a member tracked for the first time — or syncing Temple after a long gap — lands a burst of rows sharing one `achieved_at`. `fetchRecentAccomplishments` uses a CTE with `row_number()` over that group and keeps only rank 1.
 
-This is deliberately the **same rule** `recent-clogs-scroller.tsx` already applies to a bulk collection-log sync (`MAX_ITEMS_PER_SYNC`), keyed the same way. An earlier design hid a player's whole first pass behind an `is_backfilled` flag instead; that was dropped because those accomplishments are real and worth seeing (a new member's inferno cape), and because it did nothing for the case that isn't a first pass at all — an existing member syncing after a year away.
+**One, not a cap.** A cap makes the artefact unlikely; the window function makes it impossible, which is the property wanted — a burst showing "100 / 250 / 500 efficient hours played" together is not an achievement, it is visibly a first sync, since nobody earns all three in the same instant. Which row survives is decided inside the window: one-off feats (null `value`) ahead of threshold milestones, then the highest threshold, then `id` so the feed doesn't reshuffle between requests.
+
+Two earlier designs were tried and dropped. Hiding a player's whole first pass behind an `is_backfilled` flag discarded real accomplishments and did nothing for the case that *isn't* a first pass — an existing member syncing after a year away. A cap of five still let one member's burst fill half the feed with consecutive milestones. Don't reintroduce a tunable count: a constant at 1 is an invitation to raise it.
 
 **When it runs.** `processPlayerData` calls it after the player record is written (it reads that record, not a live API), so the batch `GET /api/update-all-players` and every calculator save both cover it — no new endpoint. The call is wrapped in its own try/catch: a member's stats landing is the point, and noticing what they add up to can wait for the next run.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ This is read by **clan members**, not developers. They do not know what a data s
 
 | Instead of | Write |
 |---|---|
-| Added `player_accomplishments` table + stateless detection hooked into `processPlayerData` | A new Accomplishments feed on the homepage shows milestones as members hit them — pets, inferno capes, collection log milestones and more. |
+| Added `player_accomplishments` table + stateless detection hooked into `processPlayerData` | A new Accomplishments feed on the homepage shows milestones as members hit them — inferno capes, collection log milestones and more. |
 | Fixed unawaited `db.transaction` in `approve-submission.ts` | Rank approvals now apply reliably every time. |
 | Bumped Drizzle, regenerated migrations, added indexes | Infrastructure upgrades to keep things running smoothly. |
 | Collapsed the Redis/Postgres split behind a single write path | Your calculator now saves changes automatically as you make them. |
@@ -163,11 +163,15 @@ The third activity feed, alongside rank ups and collection log — the notable t
 
 A player crossing several thresholds at once earns **all** of them (1,100 clog slots → 100/250/500/750/1000), and Grandmaster CAs earn Master too. That is deliberate and follows from statelessness.
 
-⚠️ **The first pass over a player is backfill.** Members join with a whole account behind them, so the first detection would otherwise dump a decade of history into the feed at once. `players.accomplishments_backfilled_at` marks that a player has had their first pass; everything found in it is written with `is_backfilled = true` and **`fetch-recent-accomplishments` filters those out**. The timestamp is set even when nothing was detected — otherwise a brand-new account would stay in backfill mode forever and its first real accomplishment would be swallowed.
+⚠️ **The feed is capped per sync, not filtered by age.** Detection stamps everything found in one run with a single timestamp, so a member tracked for the first time — or syncing Temple after a long gap — lands a burst of rows sharing one `achieved_at`. `fetchRecentAccomplishments` shows at most `maxAccomplishmentsPerSync` (5) from any one `(player, achieved_at)` group.
+
+This is deliberately the **same rule** `recent-clogs-scroller.tsx` already applies to a bulk collection-log sync (`MAX_ITEMS_PER_SYNC`), keyed the same way. An earlier design hid a player's whole first pass behind an `is_backfilled` flag instead; that was dropped because those accomplishments are real and worth seeing (a new member's inferno cape), and because it did nothing for the case that isn't a first pass at all — an existing member syncing after a year away.
 
 **When it runs.** `processPlayerData` calls it after the player record is written (it reads that record, not a live API), so the batch `GET /api/update-all-players` and every calculator save both cover it — no new endpoint. The call is wrapped in its own try/catch: a member's stats landing is the point, and noticing what they add up to can wait for the next run.
 
-**Icons come from the type**, resolved as OSRS Wiki image names through `formatWikiImageUrl` exactly like clog items (`ItemImageWithFallback` degrades to an avatar if the wiki renames one). The one exception is `icon_item_name`, which a row sets when the accomplishment names its own item — a pet is its own picture.
+**Icons come from the type**, resolved as OSRS Wiki image names through `formatWikiImageUrl` exactly like clog items (`ItemImageWithFallback` degrades to an avatar if the wiki renames one). There is no per-row icon override — the type is the whole presentation decision.
+
+**Pets are not accomplishments.** Every pet is a collection log slot, so it already appears in the collection-log feed alongside every other drop; announcing it again in a second feed on the same page adds nothing. Spec'd in `detect-accomplishments.spec.ts` so it doesn't get re-added by accident.
 
 **Accomplishments follow the player.** `deletePlayer` deletes them and the rename path in `edit-player-action.ts` moves them; miss the rename and the next pass treats the player as brand new and re-earns the lot.
 

--- a/apps/web/app/components/recent-accomplishments-table.tsx
+++ b/apps/web/app/components/recent-accomplishments-table.tsx
@@ -17,7 +17,6 @@ interface AccomplishmentData {
   playerName: string;
   type: AccomplishmentType;
   label: string;
-  iconItemName: string | null;
   achievedAt: Date;
 }
 
@@ -52,15 +51,13 @@ export function RecentAccomplishmentsTable({
       {header}
       <div className={styles.list}>
         {accomplishments.map((accomplishment) => {
-          // A pet is its own picture; everything else is identified by its type.
-          const iconName =
-            accomplishment.iconItemName ??
-            accomplishmentTypeIcons[accomplishment.type];
-
           return (
             <div key={accomplishment.id} className={styles.row}>
               <div className={styles.tile}>
-                <ItemImageWithFallback itemName={iconName} size={30} />
+                <ItemImageWithFallback
+                  itemName={accomplishmentTypeIcons[accomplishment.type]}
+                  size={30}
+                />
               </div>
               <div className={styles.body}>
                 <span className={styles.title}>{accomplishment.label}</span>

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,12 +5,10 @@ import { fetchRecentRankUps } from '@/app/data-sources/fetch-recent-rank-ups';
 import { fetchRecentClogUpdates } from '@/app/data-sources/fetch-recent-clog-updates';
 import { fetchRecentAccomplishments } from '@/app/data-sources/fetch-recent-accomplishments';
 import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
-import { fetchUserRecentClogs } from '@/app/data-sources/fetch-user-recent-clogs';
 import { fetchLeaderboard } from '@/app/data-sources/fetch-leaderboard';
 import { RecentRankUpsTable } from '@/app/components/recent-rank-ups-table';
 import { RecentClogUpdatesTable } from '@/app/components/recent-clog-updates-table';
 import { RecentAccomplishmentsTable } from '@/app/components/recent-accomplishments-table';
-import { RecentClogsContainer } from '@/app/components/recent-clogs-container';
 import { Leaderboard } from '@/app/components/leaderboard';
 import { NavBar } from '@/app/components/nav-bar';
 
@@ -45,15 +43,6 @@ export default async function DashboardPage() {
 
   // Fetch user's calculators
   const userCalculators = await fetchPlayerAccounts();
-
-  // Fetch user's recent collection log items
-  const playerNames = Object.values(userCalculators).map(
-    (player: { rsn: string }) => player.rsn,
-  );
-  const userRecentClogsResult = await fetchUserRecentClogs(playerNames, 20, 0);
-  const userRecentClogs = userRecentClogsResult.success
-    ? userRecentClogsResult.data
-    : [];
 
   // Fetch leaderboard data
   const leaderboardResult = await fetchLeaderboard(50, 0);
@@ -96,34 +85,12 @@ export default async function DashboardPage() {
             maxWidth: '1200px',
           }}
         >
-          {/* User's Recent Clogs */}
-          {playerNames.length > 0 && (
-            <div style={{ marginBottom: '3rem' }}>
-              <div
-                style={{
-                  textAlign: 'center',
-                  marginBottom: '1rem',
-                }}
-              >
-                <h2
-                  style={{
-                    fontFamily: 'var(--font-display), ui-sans-serif, system-ui',
-                    color: 'rgb(var(--ig-text))',
-                    fontSize: '1.5rem',
-                    fontWeight: 600,
-                    letterSpacing: '-0.01em',
-                    margin: 0,
-                  }}
-                >
-                  Your Latest Collection Logs
-                </h2>
-              </div>
-              <RecentClogsContainer
-                initialItems={userRecentClogs}
-                playerNames={playerNames}
-              />
-            </div>
-          )}
+          {/* "Your Latest Collection Logs" used to sit here. Removed on member
+              feedback: it showed you your own recent clog items, which is
+              exactly what the collection log in game already does. The
+              components and their API route are kept — nothing about them is
+              wrong, there is just no reason to render them here. */}
+
           {/* Leaderboard section */}
           <div
             style={{

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -161,49 +161,23 @@ export default async function DashboardPage() {
             </p>
           </div>
 
-          {/* Accomplishments — the headline feed, full width above the
-              narrower rank-up and collection-log columns. Hidden entirely
-              until there is something to show; see the note on the homepage. */}
-          {recentAccomplishments.length > 0 && (
-            <div
-              style={{
-                maxWidth: '1200px',
-                margin: '0 auto 2rem',
-              }}
-            >
+          {/* The three activity feeds, side by side on a wide screen. See the
+              note on the homepage — same grid, same reasoning. */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+              gap: '2rem',
+              width: '100%',
+            }}
+          >
+            <RecentRankUpsTable rankUps={recentRankUps ?? []} />
+            {recentAccomplishments.length > 0 && (
               <RecentAccomplishmentsTable
                 accomplishments={recentAccomplishments}
               />
-            </div>
-          )}
-
-          <div
-            style={{
-              display: 'flex',
-              gap: '2rem',
-              flexDirection: 'row',
-              justifyContent: 'center',
-              flexWrap: 'wrap',
-            }}
-          >
-            <div
-              style={{
-                flex: '1 1 400px',
-                minWidth: '400px',
-                maxWidth: '500px',
-              }}
-            >
-              <RecentRankUpsTable rankUps={recentRankUps ?? []} />
-            </div>
-            <div
-              style={{
-                flex: '1 1 400px',
-                minWidth: '400px',
-                maxWidth: '500px',
-              }}
-            >
-              <RecentClogUpdatesTable clogUpdates={recentClogUpdates ?? []} />
-            </div>
+            )}
+            <RecentClogUpdatesTable clogUpdates={recentClogUpdates ?? []} />
           </div>
         </div>
       </div>

--- a/apps/web/app/data-sources/fetch-recent-accomplishments.ts
+++ b/apps/web/app/data-sources/fetch-recent-accomplishments.ts
@@ -1,38 +1,37 @@
 import { db } from '@/lib/db';
 import { playerAccomplishments, players } from '@/lib/db/schema';
-import { and, desc, eq, sql } from 'drizzle-orm';
-import {
-  accomplishmentFeedSize,
-  maxAccomplishmentsPerSync,
-} from '@/config/accomplishments';
+import { sql } from 'drizzle-orm';
+import { accomplishmentFeedSize } from '@/config/accomplishments';
+import type { AccomplishmentType } from '@/app/schemas/accomplishments';
 
 export interface RecentAccomplishment {
   id: string;
   playerName: string;
-  type: (typeof playerAccomplishments.$inferSelect)['type'];
+  type: AccomplishmentType;
   label: string;
   achievedAt: Date;
 }
 
 /**
- * The clan's latest accomplishments, newest first.
+ * The clan's latest accomplishments, newest first — **at most one per player
+ * per detection run**.
  *
- * **Capped per sync.** Detection reports everything a player currently
- * qualifies for and stamps everything found in one run with a single
- * timestamp. So a member whose account has just been tracked for the first
- * time — or who has finally synced Temple after a year away — produces a burst
- * of rows sharing one `achieved_at`, and without a cap that one member fills
- * the feed.
+ * Detection stamps everything found in a single run with one timestamp, so a
+ * member being tracked for the first time, or syncing Temple after a long gap,
+ * produces a burst of rows sharing one `achieved_at`. Left alone that member
+ * fills the feed — but worse, the burst reads as an artefact rather than an
+ * achievement: nobody earns 100, 250 and 500 efficient hours played in the same
+ * instant, and a first sync reports exactly that.
  *
- * This is the same rule the collection-log rail already applies to a bulk clog
- * sync (`MAX_ITEMS_PER_SYNC` in `recent-clogs-scroller.tsx`), for the same
- * reason and keyed the same way: `(player, timestamp)`.
+ * Taking one row per `(player, achieved_at)` makes that **structurally
+ * impossible** rather than merely unlikely, which is why this is a
+ * `row_number()` over the group rather than a cap on how many may appear.
  *
- * Capping rather than hiding is deliberate. Those accomplishments are real, and
- * a new member's inferno cape is worth seeing — it just should not arrive as
- * forty rows at once. A cap also covers the case hiding never could: an
- * *existing* member syncing after a long gap, whose burst is not a first pass
- * at all and so would never have been marked as backfill.
+ * **Which one survives** is decided by the `order by` inside the window:
+ * one-off feats first (an inferno cape beats a round number), then the highest
+ * threshold reached, then id as a deterministic tiebreak so the feed doesn't
+ * reshuffle between requests. The exact winner matters little in what is a
+ * niche case — that it is *guaranteed* to be one is the point.
  *
  * Mains are included — they are members, and this is not the ladder.
  */
@@ -40,40 +39,55 @@ export async function fetchRecentAccomplishments(
   limit = accomplishmentFeedSize,
 ) {
   try {
-    const recentAccomplishments = await db
-      .select({
-        id: playerAccomplishments.id,
-        playerName: playerAccomplishments.playerName,
-        type: playerAccomplishments.type,
-        label: playerAccomplishments.label,
-        achievedAt: playerAccomplishments.achievedAt,
-      })
-      .from(playerAccomplishments)
-      .innerJoin(
-        players,
-        eq(players.playerName, playerAccomplishments.playerName),
-      )
-      .where(
-        and(
-          // Still in the clan.
-          eq(players.isActive, true),
-          // At most `maxAccomplishmentsPerSync` from any one detection run.
-          // Ranked inside the group by id so the choice is stable between
-          // requests, and applied here rather than by filtering the results in
-          // JS — that would return fewer rows than the caller asked for.
-          sql`(
-            select count(*)
-            from ${playerAccomplishments} as peer
-            where peer.player_name = ${playerAccomplishments.playerName}
-              and peer.achieved_at = ${playerAccomplishments.achievedAt}
-              and peer.id <= ${playerAccomplishments.id}
-          ) <= ${maxAccomplishmentsPerSync}`,
-        ),
-      )
-      .orderBy(desc(playerAccomplishments.achievedAt))
-      .limit(limit);
+    const rows = await db.execute<{
+      id: string;
+      player_name: string;
+      type: AccomplishmentType;
+      label: string;
+      achieved_at: Date;
+    }>(
+      sql`
+        with ranked as (
+          select
+            ${playerAccomplishments.id} as id,
+            ${playerAccomplishments.playerName} as player_name,
+            ${playerAccomplishments.type} as type,
+            ${playerAccomplishments.label} as label,
+            ${playerAccomplishments.achievedAt} as achieved_at,
+            row_number() over (
+              partition by
+                ${playerAccomplishments.playerName},
+                ${playerAccomplishments.achievedAt}
+              order by
+                -- One-off feats (null value) ahead of threshold milestones...
+                (${playerAccomplishments.value} is null) desc,
+                -- ...then the biggest number reached...
+                ${playerAccomplishments.value} desc,
+                -- ...then something stable, so the feed doesn't reshuffle.
+                ${playerAccomplishments.id}
+            ) as rank
+          from ${playerAccomplishments}
+          inner join ${players}
+            on ${players.playerName} = ${playerAccomplishments.playerName}
+          where ${players.isActive} = true
+        )
+        select id, player_name, type, label, achieved_at
+        from ranked
+        where rank = 1
+        order by achieved_at desc
+        limit ${limit}
+      `,
+    );
 
-    return { success: true, data: recentAccomplishments };
+    const data: RecentAccomplishment[] = Array.from(rows).map((row) => ({
+      id: row.id,
+      playerName: row.player_name,
+      type: row.type,
+      label: row.label,
+      achievedAt: new Date(row.achieved_at),
+    }));
+
+    return { success: true, data };
   } catch (error) {
     console.error('Failed to fetch recent accomplishments:', error);
     return { success: false, error: String(error) };

--- a/apps/web/app/data-sources/fetch-recent-accomplishments.ts
+++ b/apps/web/app/data-sources/fetch-recent-accomplishments.ts
@@ -1,24 +1,40 @@
 import { db } from '@/lib/db';
 import { playerAccomplishments, players } from '@/lib/db/schema';
-import { and, desc, eq } from 'drizzle-orm';
-import { accomplishmentFeedSize } from '@/config/accomplishments';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import {
+  accomplishmentFeedSize,
+  maxAccomplishmentsPerSync,
+} from '@/config/accomplishments';
 
 export interface RecentAccomplishment {
   id: string;
   playerName: string;
   type: (typeof playerAccomplishments.$inferSelect)['type'];
   label: string;
-  iconItemName: string | null;
   achievedAt: Date;
 }
 
 /**
  * The clan's latest accomplishments, newest first.
  *
- * Backfilled rows are excluded: they are real accomplishments, but they were
- * found in a player's first detection pass and we have no idea when they
- * happened, so they are not news. Mains are included — they are members, and
- * this is not the ladder.
+ * **Capped per sync.** Detection reports everything a player currently
+ * qualifies for and stamps everything found in one run with a single
+ * timestamp. So a member whose account has just been tracked for the first
+ * time — or who has finally synced Temple after a year away — produces a burst
+ * of rows sharing one `achieved_at`, and without a cap that one member fills
+ * the feed.
+ *
+ * This is the same rule the collection-log rail already applies to a bulk clog
+ * sync (`MAX_ITEMS_PER_SYNC` in `recent-clogs-scroller.tsx`), for the same
+ * reason and keyed the same way: `(player, timestamp)`.
+ *
+ * Capping rather than hiding is deliberate. Those accomplishments are real, and
+ * a new member's inferno cape is worth seeing — it just should not arrive as
+ * forty rows at once. A cap also covers the case hiding never could: an
+ * *existing* member syncing after a long gap, whose burst is not a first pass
+ * at all and so would never have been marked as backfill.
+ *
+ * Mains are included — they are members, and this is not the ladder.
  */
 export async function fetchRecentAccomplishments(
   limit = accomplishmentFeedSize,
@@ -30,7 +46,6 @@ export async function fetchRecentAccomplishments(
         playerName: playerAccomplishments.playerName,
         type: playerAccomplishments.type,
         label: playerAccomplishments.label,
-        iconItemName: playerAccomplishments.iconItemName,
         achievedAt: playerAccomplishments.achievedAt,
       })
       .from(playerAccomplishments)
@@ -40,10 +55,19 @@ export async function fetchRecentAccomplishments(
       )
       .where(
         and(
-          // Still in the clan...
+          // Still in the clan.
           eq(players.isActive, true),
-          // ...and not something we merely noticed on their first pass.
-          eq(playerAccomplishments.isBackfilled, false),
+          // At most `maxAccomplishmentsPerSync` from any one detection run.
+          // Ranked inside the group by id so the choice is stable between
+          // requests, and applied here rather than by filtering the results in
+          // JS — that would return fewer rows than the caller asked for.
+          sql`(
+            select count(*)
+            from ${playerAccomplishments} as peer
+            where peer.player_name = ${playerAccomplishments.playerName}
+              and peer.achieved_at = ${playerAccomplishments.achievedAt}
+              and peer.id <= ${playerAccomplishments.id}
+          ) <= ${maxAccomplishmentsPerSync}`,
         ),
       )
       .orderBy(desc(playerAccomplishments.achievedAt))

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -204,56 +204,31 @@ export default async function HomePage() {
                 <Leaderboard initialPlayers={leaderboard} />
               </div>
 
-              {/* Accomplishments — the headline feed, full width above the
-                  narrower rank-up and collection-log columns.
+              {/* The three activity feeds, side by side on a wide screen.
+                  auto-fit collapses them to two, then one, without any
+                  breakpoint arithmetic — and `align-items: stretch` (the grid
+                  default) keeps the cards the same height, which the fixed
+                  `max-height` on `.list` already assumes.
 
-                  Hidden entirely until there is something to show. Unlike the
-                  other two feeds this one starts empty by design: a player's
-                  first detection pass is recorded as backfill and kept out of
-                  the feed, so an empty-state card would sit on the homepage
-                  for weeks after launch announcing that nothing has happened.
-                  Guarded here rather than inside the component because the
-                  parent is a flex column with a gap — an element that renders
-                  nothing still leaves a hole. */}
-              {recentAccomplishments.length > 0 && (
-                <div style={{ width: '100%', maxWidth: '1250px' }}>
+                  Accomplishments is conditional: with nothing to show it would
+                  otherwise leave an empty grid cell, and a column of whitespace
+                  reads worse than two columns. */}
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+                  gap: '2rem',
+                  width: '100%',
+                  maxWidth: '1250px',
+                }}
+              >
+                <RecentRankUpsTable rankUps={recentRankUps ?? []} />
+                {recentAccomplishments.length > 0 && (
                   <RecentAccomplishmentsTable
                     accomplishments={recentAccomplishments}
                   />
-                </div>
-              )}
-
-              {/* Recent activity tables */}
-              <div
-                style={{
-                  display: 'flex',
-                  gap: '2rem',
-                  flexDirection: 'row',
-                  justifyContent: 'center',
-                  flexWrap: 'wrap',
-                  width: '100%',
-                }}
-              >
-                <div
-                  style={{
-                    flex: '1 1 400px',
-                    minWidth: '400px',
-                    maxWidth: '500px',
-                  }}
-                >
-                  <RecentRankUpsTable rankUps={recentRankUps ?? []} />
-                </div>
-                <div
-                  style={{
-                    flex: '1 1 400px',
-                    minWidth: '400px',
-                    maxWidth: '500px',
-                  }}
-                >
-                  <RecentClogUpdatesTable
-                    clogUpdates={recentClogUpdates ?? []}
-                  />
-                </div>
+                )}
+                <RecentClogUpdatesTable clogUpdates={recentClogUpdates ?? []} />
               </div>
 
               {/* Rarest collection-log items across the clan */}

--- a/apps/web/app/schemas/accomplishments.ts
+++ b/apps/web/app/schemas/accomplishments.ts
@@ -25,7 +25,6 @@ export const AccomplishmentType = z.enum([
   'blood_torva',
   'radiant_oathplate',
   'toa_cursed_phalanx',
-  'pet',
 ]);
 
 export type AccomplishmentType = z.infer<typeof AccomplishmentType>;
@@ -63,7 +62,6 @@ export const accomplishmentTypeLabels = {
   blood_torva: 'Cosmetic',
   radiant_oathplate: 'Cosmetic',
   toa_cursed_phalanx: 'Tombs of Amascut',
-  pet: 'Pet',
 } as const satisfies Record<AccomplishmentType, string>;
 
 /**
@@ -91,5 +89,4 @@ export const accomplishmentTypeIcons = {
   blood_torva: 'Sanguine torva platebody',
   radiant_oathplate: 'Radiant oathplate chest',
   toa_cursed_phalanx: 'Cursed phalanx',
-  pet: 'Collection log',
 } as const satisfies Record<AccomplishmentType, string>;

--- a/apps/web/app/utils/detect-accomplishments.spec.ts
+++ b/apps/web/app/utils/detect-accomplishments.spec.ts
@@ -136,29 +136,27 @@ describe('detectAccomplishments', () => {
   });
 
   describe('items', () => {
-    const petSnakeling = {
-      itemId: 12921,
-      itemName: 'Pet snakeling',
-      dateFirstLogged: new Date('2024-03-01T00:00:00.000Z'),
-    };
-
-    it('awards a pet, and lets it carry its own icon', () => {
-      const [pet] = detectAccomplishments({
-        ...emptySnapshot,
-        acquiredItems: [petSnakeling],
-      });
-
-      expect(pet).toEqual({
-        type: 'pet',
-        key: 'pet:12921',
-        label: 'Pet snakeling',
-        value: null,
-        iconItemName: 'Pet snakeling',
-        achievedAt: petSnakeling.dateFirstLogged,
-      });
+    /**
+     * Pets are deliberately *not* accomplishments. Every pet is a collection
+     * log slot, so it already appears in the collection-log feed alongside
+     * every other drop — announcing it twice, in two feeds on the same page,
+     * says nothing extra.
+     */
+    it('ignores a pet, which the collection log feed already covers', () => {
+      expect(
+        keysOf({
+          acquiredItems: [
+            {
+              itemId: 12921,
+              itemName: 'Pet snakeling',
+              dateFirstLogged: new Date('2024-03-01T00:00:00.000Z'),
+            },
+          ],
+        }),
+      ).toEqual([]);
     });
 
-    it('ignores an item that is not a pet', () => {
+    it('ignores an ordinary collection log item', () => {
       expect(
         keysOf({
           acquiredItems: [
@@ -223,11 +221,6 @@ describe('detectAccomplishments', () => {
       hasAchievementDiaryCape: true,
       eliteDiaryLocations: ['Morytania', 'Karamja'],
       acquiredItems: [
-        {
-          itemId: 12921,
-          itemName: 'Pet snakeling',
-          dateFirstLogged: new Date(),
-        },
         {
           itemId: 27377,
           itemName: 'Cursed phalanx',

--- a/apps/web/app/utils/detect-accomplishments.ts
+++ b/apps/web/app/utils/detect-accomplishments.ts
@@ -1,5 +1,4 @@
 import {
-  AllPetItemIds,
   CombatAchievementTier,
   DiaryTier,
   maximumTotalLevel,
@@ -51,8 +50,6 @@ export interface DetectedAccomplishment {
   label: string;
   /** The threshold reached, for milestones. Null for one-off feats. */
   value: number | null;
-  /** Overrides the type's icon where the accomplishment names its own item. */
-  iconItemName: string | null;
   /**
    * When it actually happened, where that is knowable — the collection log
    * carries its own dates. Null means "we only know we can see it now", and the
@@ -60,8 +57,6 @@ export interface DetectedAccomplishment {
    */
   achievedAt: Date | null;
 }
-
-const petItemIds = new Set(AllPetItemIds);
 
 const combatAchievementTierOrder = CombatAchievementTier.options;
 
@@ -98,7 +93,6 @@ function detectMilestones(
       key: `${type}:${threshold}`,
       label: label(threshold),
       value: threshold,
-      iconItemName: null,
       achievedAt: null,
     }));
 }
@@ -144,7 +138,6 @@ export function detectAccomplishments(
       key: 'maxed',
       label: `Maxed — level 99 in all ${skillsCount} skills`,
       value: maximumTotalLevel,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -158,7 +151,6 @@ export function detectAccomplishments(
       key: `elite_diary:${location}`,
       label: `${location} elite diary`,
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   });
@@ -169,7 +161,6 @@ export function detectAccomplishments(
       key: 'diary_cape',
       label: 'Achievement diary cape',
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -186,7 +177,6 @@ export function detectAccomplishments(
         key: `combat_achievement:${tier}`,
         label: `${tier} combat achievements`,
         value: null,
-        iconItemName: null,
         achievedAt: null,
       });
     });
@@ -197,7 +187,6 @@ export function detectAccomplishments(
       key: 'inferno',
       label: 'Completed the Inferno',
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -208,7 +197,6 @@ export function detectAccomplishments(
       key: 'colosseum',
       label: 'Completed the Fortis Colosseum',
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -219,7 +207,6 @@ export function detectAccomplishments(
       key: 'blood_torva',
       label: 'Blood torva',
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -230,7 +217,6 @@ export function detectAccomplishments(
       key: 'radiant_oathplate',
       label: 'Radiant oathplate',
       value: null,
-      iconItemName: null,
       achievedAt: null,
     });
   }
@@ -242,19 +228,6 @@ export function detectAccomplishments(
         key: 'toa_cursed_phalanx',
         label: 'Cursed phalanx — Tombs of Amascut at 500 invocation',
         value: null,
-        iconItemName: null,
-        achievedAt: item.dateFirstLogged,
-      });
-    }
-
-    if (petItemIds.has(item.itemId)) {
-      accomplishments.push({
-        type: 'pet',
-        key: `pet:${item.itemId}`,
-        label: item.itemName,
-        value: null,
-        // A pet is its own picture, so the row overrides the type's icon.
-        iconItemName: item.itemName,
         achievedAt: item.dateFirstLogged,
       });
     }

--- a/apps/web/config/accomplishments.ts
+++ b/apps/web/config/accomplishments.ts
@@ -36,3 +36,17 @@ export const cursedPhalanxItemName = 'Cursed phalanx';
 
 /** How many accomplishments the homepage and dashboard feeds show. */
 export const accomplishmentFeedSize = 10;
+
+/**
+ * How many accomplishments from a single detection run may appear in the feed.
+ *
+ * Detection stamps everything it finds in one pass with the same timestamp, so
+ * a member being tracked for the first time — or syncing Temple after a long
+ * gap — lands a burst of rows sharing one `achieved_at`. Without a cap, that
+ * one member fills the feed.
+ *
+ * Matches `MAX_ITEMS_PER_SYNC` in `recent-clogs-scroller.tsx`, which solves the
+ * identical problem for a bulk collection-log sync. Kept as a separate constant
+ * rather than shared, because the two feeds are free to tune independently.
+ */
+export const maxAccomplishmentsPerSync = 5;

--- a/apps/web/config/accomplishments.ts
+++ b/apps/web/config/accomplishments.ts
@@ -36,17 +36,3 @@ export const cursedPhalanxItemName = 'Cursed phalanx';
 
 /** How many accomplishments the homepage and dashboard feeds show. */
 export const accomplishmentFeedSize = 10;
-
-/**
- * How many accomplishments from a single detection run may appear in the feed.
- *
- * Detection stamps everything it finds in one pass with the same timestamp, so
- * a member being tracked for the first time — or syncing Temple after a long
- * gap — lands a burst of rows sharing one `achieved_at`. Without a cap, that
- * one member fills the feed.
- *
- * Matches `MAX_ITEMS_PER_SYNC` in `recent-clogs-scroller.tsx`, which solves the
- * identical problem for a bulk collection-log sync. Kept as a separate constant
- * rather than shared, because the two feeds are free to tune independently.
- */
-export const maxAccomplishmentsPerSync = 5;

--- a/apps/web/drizzle/0021_low_mordo.sql
+++ b/apps/web/drizzle/0021_low_mordo.sql
@@ -1,0 +1,15 @@
+-- Hand-added, and required: the last statement in this file casts every
+-- existing `type` value into the recreated enum, and any surviving 'pet' row
+-- would fail that cast with `invalid input value for enum`. The backfill has
+-- already written pet rows, so this is not hypothetical.
+--
+-- Pets stop being accomplishments here. Every pet is a collection log slot, so
+-- it already appears in the collection-log feed alongside every other drop.
+DELETE FROM "player_accomplishments" WHERE "type" = 'pet';--> statement-breakpoint
+ALTER TABLE "player_accomplishments" DROP COLUMN IF EXISTS "icon_item_name";--> statement-breakpoint
+ALTER TABLE "player_accomplishments" DROP COLUMN IF EXISTS "is_backfilled";--> statement-breakpoint
+ALTER TABLE "players" DROP COLUMN IF EXISTS "accomplishments_backfilled_at";--> statement-breakpoint
+ALTER TABLE "public"."player_accomplishments" ALTER COLUMN "type" SET DATA TYPE text;--> statement-breakpoint
+DROP TYPE "public"."accomplishment_type";--> statement-breakpoint
+CREATE TYPE "public"."accomplishment_type" AS ENUM('collection_log', 'total_level', 'ehb', 'ehp', 'maxed', 'elite_diary', 'diary_cape', 'combat_achievement', 'inferno', 'colosseum', 'blood_torva', 'radiant_oathplate', 'toa_cursed_phalanx');--> statement-breakpoint
+ALTER TABLE "public"."player_accomplishments" ALTER COLUMN "type" SET DATA TYPE "public"."accomplishment_type" USING "type"::"public"."accomplishment_type";

--- a/apps/web/drizzle/meta/0021_snapshot.json
+++ b/apps/web/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,759 @@
+{
+  "id": "bd33dca1-5ef5-44ba-9319-5da90e6229e7",
+  "prevId": "4e7a9852-92e5-429d-aaeb-d7851fc4342f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.player_accomplishments": {
+      "name": "player_accomplishments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "accomplishment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accomplishment_key": {
+          "name": "accomplishment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_accomplishments_achieved_at_idx": {
+          "name": "player_accomplishments_achieved_at_idx",
+          "columns": [
+            {
+              "expression": "achieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_accomplishments_player_name_accomplishment_key_unique": {
+          "name": "player_accomplishments_player_name_accomplishment_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "accomplishment_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_achievement_diaries": {
+      "name": "player_achievement_diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_acquired_items": {
+      "name": "player_acquired_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_category": {
+          "name": "item_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_first_logged": {
+          "name": "date_first_logged",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_acquired_items_item_id_idx": {
+          "name": "player_acquired_items_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_acquired_items_player_name_item_id_unique": {
+          "name": "player_acquired_items_player_name_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_item_overrides": {
+      "name": "player_item_overrides",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_acquired": {
+          "name": "is_acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_item_overrides_player_name_item_name_pk": {
+          "name": "player_item_overrides_player_name_item_name_pk",
+          "columns": [
+            "player_name",
+            "item_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_rank_ups": {
+      "name": "player_rank_ups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "old_rank": {
+          "name": "old_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_rank": {
+          "name": "new_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ehb": {
+          "name": "ehb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ehp": {
+          "name": "ehp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_achievement_tier": {
+          "name": "combat_achievement_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_link": {
+          "name": "proof_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_log_count": {
+          "name": "collection_log_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_total": {
+          "name": "collection_log_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_level": {
+          "name": "total_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1154
+        },
+        "clue_count_beginner": {
+          "name": "clue_count_beginner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_easy": {
+          "name": "clue_count_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_medium": {
+          "name": "clue_count_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_hard": {
+          "name": "clue_count_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_elite": {
+          "name": "clue_count_elite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_master": {
+          "name": "clue_count_master",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tzhaar_cape": {
+          "name": "tzhaar_cape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "has_blood_torva": {
+          "name": "has_blood_torva",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_radiant_oathplate": {
+          "name": "has_radiant_oathplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dizanas_quiver": {
+          "name": "has_dizanas_quiver",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_achievement_diary_cape": {
+          "name": "has_achievement_diary_cape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "combat_bonus_points": {
+          "name": "combat_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skilling_bonus_points": {
+          "name": "skilling_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_bonus_points": {
+          "name": "collection_log_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notable_items_bonus_points": {
+          "name": "notable_items_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile_only": {
+          "name": "is_mobile_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gim_group_name": {
+          "name": "gim_group_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_player_name_lower_unique": {
+          "name": "players_player_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"player_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_role_changes": {
+      "name": "staff_role_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_role": {
+          "name": "old_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_role": {
+          "name": "new_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_player_name": {
+          "name": "changed_by_player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_discord_user_id": {
+          "name": "changed_by_discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_role_changes_player_name_idx": {
+          "name": "staff_role_changes_player_name_idx",
+          "columns": [
+            {
+              "expression": "player_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.accomplishment_type": {
+      "name": "accomplishment_type",
+      "schema": "public",
+      "values": [
+        "collection_log",
+        "total_level",
+        "ehb",
+        "ehp",
+        "maxed",
+        "elite_diary",
+        "diary_cape",
+        "combat_achievement",
+        "inferno",
+        "colosseum",
+        "blood_torva",
+        "radiant_oathplate",
+        "toa_cursed_phalanx"
+      ]
+    },
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "main",
+        "ironman",
+        "hardcore_ironman",
+        "ultimate_ironman",
+        "group_ironman",
+        "hardcore_group_ironman",
+        "unranked_group_ironman"
+      ]
+    },
+    "public.staff_role": {
+      "name": "staff_role",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "admin",
+        "deputy_owner",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1787334045753,
       "tag": "0020_smart_arclight",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1787344571965,
+      "tag": "0021_low_mordo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/accomplishment-operations.ts
+++ b/apps/web/lib/db/accomplishment-operations.ts
@@ -18,11 +18,6 @@ export interface SyncPlayerAccomplishmentsResult {
   detected: number;
   /** How many of those were new, and so written. */
   recorded: number;
-  /**
-   * Whether this was the player's first pass, in which case the rows written
-   * are marked as backfill and kept out of the feed.
-   */
-  backfilled: boolean;
 }
 
 /**
@@ -33,10 +28,11 @@ export interface SyncPlayerAccomplishmentsResult {
  * stopped achieving things. It reads the player's stored record rather than any
  * live API, so it belongs *after* whatever refreshed that record.
  *
- * The first pass over a player is recorded as backfill. Members join with a
- * whole account behind them and the detector reports everything it can see, so
- * without this the feed's first render would be a decade of other people's
- * history — see `players.accomplishments_backfilled_at`.
+ * A player's first pass finds everything they already qualify for at once, and
+ * that is fine: those are real accomplishments and the feed shows them. What
+ * stops one member's first sync filling the whole feed is the per-sync cap in
+ * `fetchRecentAccomplishments`, which is the same rule the collection-log rail
+ * already uses.
  */
 export async function syncPlayerAccomplishments(
   playerName: string,
@@ -54,14 +50,13 @@ export async function syncPlayerAccomplishments(
       hasRadiantOathplate: players.hasRadiantOathplate,
       hasDizanasQuiver: players.hasDizanasQuiver,
       hasAchievementDiaryCape: players.hasAchievementDiaryCape,
-      accomplishmentsBackfilledAt: players.accomplishmentsBackfilledAt,
     })
     .from(players)
     .where(eq(players.playerName, playerName))
     .limit(1);
 
   if (!player) {
-    return { detected: 0, recorded: 0, backfilled: false };
+    return { detected: 0, recorded: 0 };
   }
 
   const [diaries, acquiredItems] = await Promise.all([
@@ -108,7 +103,6 @@ export async function syncPlayerAccomplishments(
     acquiredItems,
   });
 
-  const isBackfill = player.accomplishmentsBackfilledAt === null;
   const now = new Date();
 
   const recorded = await db.transaction(async (tx) => {
@@ -123,8 +117,6 @@ export async function syncPlayerAccomplishments(
                 accomplishmentKey: accomplishment.key,
                 label: accomplishment.label,
                 value: accomplishment.value,
-                iconItemName: accomplishment.iconItemName,
-                isBackfilled: isBackfill,
                 // The collection log knows when a drop happened; nothing else
                 // does, so the rest are dated from this run.
                 achievedAt: accomplishment.achievedAt ?? now,
@@ -139,24 +131,12 @@ export async function syncPlayerAccomplishments(
             .returning({ id: playerAccomplishments.id })
         : [];
 
-    if (isBackfill) {
-      // Set unconditionally, including for a player who qualified for nothing —
-      // otherwise a brand new account would stay in backfill mode forever and
-      // its first real accomplishment would be silently swallowed.
-      await tx
-        .update(players)
-        .set({ accomplishmentsBackfilledAt: now })
-        .where(eq(players.playerName, playerName));
-    }
-
     return inserted.length;
   });
 
   if (recorded > 0) {
-    console.log(
-      `Recorded ${recorded} ${isBackfill ? 'backfilled ' : ''}accomplishment(s) for ${playerName}`,
-    );
+    console.log(`Recorded ${recorded} accomplishment(s) for ${playerName}`);
   }
 
-  return { detected: detected.length, recorded, backfilled: isBackfill };
+  return { detected: detected.length, recorded };
 }

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -57,7 +57,6 @@ export const accomplishmentTypeEnum = pgEnum('accomplishment_type', [
   'blood_torva',
   'radiant_oathplate',
   'toa_cursed_phalanx',
-  'pet',
 ]);
 
 export const accountTypeEnum = pgEnum('account_type', [
@@ -151,16 +150,6 @@ export const players = pgTable(
     // the Temple group) are hidden from the leaderboard but their row is kept
     // so they can be restored automatically if they become active again.
     isActive: boolean('is_active').notNull().default(true),
-
-    // When this player's accomplishments were first detected.
-    //
-    // The detector reports everything a player *currently* qualifies for, so
-    // the first pass over an existing member would announce a decade of
-    // achievements at once. That first pass is instead recorded as backfill
-    // (`player_accomplishments.is_backfilled`) and kept out of the feed; this
-    // column is what tells the two passes apart, and it must be per-player
-    // because members keep joining with a full account behind them.
-    accomplishmentsBackfilledAt: timestamp('accomplishments_backfilled_at'),
 
     // Metadata
     createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -363,19 +352,6 @@ export const playerAccomplishments = pgTable(
 
     /** The threshold reached, for milestones. Null for one-off feats. */
     value: real('value'),
-
-    /**
-     * Overrides the type's configured icon where the accomplishment names its
-     * own item — a pet is its own picture. Null means use the type's icon.
-     */
-    iconItemName: text('icon_item_name'),
-
-    /**
-     * True for everything found in the player's very first detection pass:
-     * real, but not news. Kept out of the feed, and the reason the feed does
-     * not explode the first time this runs over an established clan.
-     */
-    isBackfilled: boolean('is_backfilled').notNull().default(false),
 
     achievedAt: timestamp('achieved_at').notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),


### PR DESCRIPTION
<!-- member-summary:start -->
The homepage and dashboard feeds have been tidied up: Rank Ups, Accomplishments and Collection Log now sit side by side, and Accomplishments shows one highlight per member instead of a wall of milestones. Pet drops no longer appear twice, and the panel that repeated your own collection log has been removed.
<!-- member-summary:end -->

Started as two review corrections to the accomplishments feed and grew into a pass over the activity feeds as a whole. Six changes, all from feedback.

---

## 1. Pets are not accomplishments

Every pet is a collection log slot, so it already appears in the collection-log feed alongside every other drop. Announcing it a second time, in another feed on the same page, says nothing extra. I flagged this duplication while building it and included them anyway — that was the wrong call.

Removing them also removes the **only** user of the per-row icon override, so `icon_item_name` goes with them. The type is now the whole presentation decision, which is what the design claimed in the first place.

## 2. One accomplishment per sync, guaranteed

Detection stamps everything found in one run with a single timestamp. So a member tracked for the first time — or syncing Temple after a long gap — produced a burst sharing one `achieved_at`, and the feed showed things like this:

```
SirBurrows   500 efficient hours played
SirBurrows   250 efficient hours played
SirBurrows   100 efficient hours played
SirBurrows   1,750 total level
SirBurrows   100 collection log slots
```

That isn't an achievement, it's visibly an artefact of a first sync — nobody earns all three EHP milestones in the same instant.

**A CTE with `row_number()` over `(player_name, achieved_at)`, keeping rank 1.** Not a cap: a cap makes the artefact unlikely, the window function makes it impossible, which is the property actually wanted. Which row survives is decided inside the window — one-off feats ahead of threshold milestones (an inferno cape beats a round number), then the highest threshold, then `id` so the feed doesn't reshuffle between requests.

Two earlier designs were tried and dropped, both recorded in CLAUDE.md so they don't come back:

- **Hiding a player's first pass** behind an `is_backfilled` flag discarded real accomplishments, and did nothing for the case that *isn't* a first pass — an existing member syncing after a year away.
- **A cap of five** still let one member fill half the feed with consecutive milestones.

`maxAccomplishmentsPerSync` is deleted rather than set to `1`; a tunable count is an invitation to raise it.

## 3. Three feeds side by side

Accomplishments was full content width above the two narrower feeds, which read badly on a large screen. All three now sit in one `auto-fit` grid — three across when there's room, collapsing to two then one with no breakpoint arithmetic. Grid's default `align-items: stretch` keeps the cards level, which the fixed `max-height: 420px` on `.list` already assumed.

Accomplishments stays conditional: with nothing to show it would leave an empty grid cell, and a column of whitespace reads worse than two columns.

## 4. "Your Latest Collection Logs" unmounted

Member feedback, and it's right — it showed you your own recent clog items, which is exactly what the collection log in game already does.

**Only the render and its query are removed.** `RecentClogsContainer`, `recent-clogs-scroller`, `fetchUserRecentClogs` and `GET /api/user-recent-clogs` are all left in place and working. Nothing about them is wrong, there's just no reason to render them here — and that scroller is the codebase's only worked horizontal infinite-scroll implementation, so deleting it would cost something for no gain.

The clan-wide **Collection Log** feed is a different thing and stays: other members' drops aren't visible in game.

## 5. Discord announcements drop the PR link

The embed carried a link to the pull request and its number in the footer. That lands in a members' channel, where a GitHub URL is noise at best and an invitation to read a diff at worst. It's now title, summary and colour. `PR_NUMBER` survives only in the workflow's own log lines, where it still helps debug a run.

## 6. ⚠️ Migration `0021` has a hand-added line, and it matters

Drizzle's generated migration ends by casting every existing `type` value into the recreated enum. **Any surviving `'pet'` row fails that cast** with `invalid input value for enum`.

The backfill run did write pet rows, so this would have failed on the first attempt. They have since been deleted by hand on the live database, which makes the statement a no-op there — it stays because the migration must be correct on any database that still has them, and because a reviewer shouldn't need that history to understand why it's first.

`0021` also drops `is_backfilled`, `icon_item_name` and `players.accomplishments_backfilled_at`.

---

## Tested

**Verified against the live database**, not just typechecked — the feed query returns 10 rows across **10 distinct players, one per sync**. The same query under the old cap returned five consecutive EHP milestones for a single member.

- 30 detector specs passing, including a new one pinning the pet exclusion so it isn't re-added by accident.
- Both typecheck projects clean; the four pre-existing `submit-rank-calculator.spec.ts` errors unchanged.
- Full Jest suite diffed against `main`: **identical**, suite for suite.
- The rewritten Discord payload built and inspected; workflow YAML still parses.
- eslint and prettier clean.
- CLAUDE.md updated throughout — the accomplishments section (which still described the cap), the two references citing the clogs scroller as a live rendering example, and a new note on the feed layout.

**Not verified:** the three-column grid and the unmounted rail have not been looked at in a browser at every width — the dashboard is Discord-auth-gated, so it needs a real login. The reasoning for `auto-fit` + `stretch` is sound but the breakpoints deserve an eye.

Migrations `0020` (from #88) and `0021` are both **unrun**. `0020` is the more urgent of the two: `player_item_overrides` doesn't exist yet, so #88's write path is currently failing into its own catch on every calculator load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
