### PR TITLE
Autosave the calculator, and delete "save"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,20 @@ Mains are included — this is not the ladder. There is **no EHC milestone**: no
 
 Icons come from **file conventions**, not `metadata.icons`: `app/favicon.ico`, `app/icon.png`, `app/apple-icon.png` (all generated from `public/L1.png`). These files **take precedence over any `icons` field in `layout.tsx` metadata** — if the favicon is wrong, it's because a stale `app/favicon.ico` exists, not the metadata. To change icons, replace those files (regenerate from the logo with `sharp`); don't add `metadata.icons`.
 
+## There is no "save"
+
+The calculator persists edits as they are made. There is no Save button, no "Saved ✓", no success toast — an edit applying and staying applied is the expected case and does not need reporting. **Do not reintroduce a save affordance**, including a passive one: an indicator that says "saved" implies a step that no longer exists.
+
+- `hooks/use-autosave.ts` — watches the form, debounces 800ms (so ticking twenty items lands as one request), flushes on tab hide and before a rank submission. `buildPlayerPatch` is pure and spec'd separately.
+- `[player]/actions/update-player-state-action.ts` — takes a **partial** patch. Its schema is a `pick` of `RankCalculatorSchema`: stats, `rank` and `points` are absent by construction, so the browser cannot assert them. The old `saveDraftRankSubmissionAction` took the whole form, which is why every page load rewrote every field.
+- `updatePlayerEditableFields` (`lib/db/player-operations.ts`) — the write. Only supplied keys are touched.
+
+The **only** UI is on failure: a toast when a write does not land, because that is the one thing the player could not otherwise know.
+
+"Apply for promotion" no longer checks `isDirty` or tells anyone to save first. It awaits a flush — the question was never "is the form dirty", it was "is what I am about to submit what they can see".
+
+⚠️ **The Redis draft is still written, and is a shim.** Nothing reads it for the calculator any more; Postgres is authoritative. But a rank submission is still a literal Redis `COPY` of the draft, so `updatePlayerStateAction` mirrors each patch into it to stop members submitting sheets that don't match their screen. When submissions snapshot from the player record instead, the draft has no readers left and `userDraftRankSubmissionKey` goes.
+
 ## Rank-calculator approvals
 
 `approveSubmission` assigns Discord roles and messages the submitter for every approval. There is one rank ladder, so there is no longer a structure to branch on (`rankDiscordRoles` covers every `StandardRank`).

--- a/apps/web/app/components/nav-bar.tsx
+++ b/apps/web/app/components/nav-bar.tsx
@@ -29,10 +29,13 @@ interface NavBarProps {
   currentPage?: 'dashboard' | 'player' | 'submission' | 'admin';
   playerName?: string;
   showSaveActions?: boolean;
-  onSave?: () => void;
-  isSaving?: boolean;
-  canSave?: boolean;
   isActionActive?: boolean;
+  /**
+   * Forces any pending autosave out before a submission snapshots the sheet.
+   * Replaces the old `onSave` / `canSave` / `isSaving` trio, which existed
+   * only to drive a Save button.
+   */
+  beforeSubmit?: () => Promise<void>;
   userCalculators?: Record<
     string,
     {
@@ -41,7 +44,6 @@ interface NavBarProps {
       joinDate: Date;
     }
   >;
-  submitForm?: () => Promise<void> | void;
   additionalButtons?: React.ReactNode;
 }
 
@@ -49,12 +51,9 @@ export function NavBar({
   currentPage = 'dashboard',
   playerName,
   showSaveActions = false,
-  onSave: _onSave,
-  isSaving: _isSaving = false,
-  canSave: _canSave = false,
   isActionActive = false,
+  beforeSubmit,
   userCalculators = {},
-  submitForm,
   additionalButtons,
 }: NavBarProps) {
   const router = useRouter();
@@ -80,7 +79,6 @@ export function NavBar({
 
   // Extract values with safe defaults
   const reset = formContext?.reset;
-  const isValid = formState?.isValid ?? false;
   const isDirty = formState?.isDirty ?? false;
   const isSubmitting = formState?.isSubmitting ?? false;
   const totalPoints = rankCalculator?.pointsAwarded ?? 0;
@@ -195,29 +193,20 @@ export function NavBar({
         <div className={styles.actions}>
           {additionalButtons}
 
+          {/* There is no Save button. Changes persist as they are made — see
+              `useAutosave`. What is left here are the actions that are not
+              "store my edits": applying for a rank, resetting, deleting. */}
           {showSaveActions && (
             <div className={styles.save}>
-              <button
-                type="button"
-                className={styles.saveMain}
-                disabled={!isDirty || !isValid || isBusy}
-                onClick={() => {
-                  if (submitForm) {
-                    void submitForm();
-                  }
-                }}
-              >
-                {isBusy && <Spinner size="1" />}
-                Save
-              </button>
               <DropdownMenu.Root modal={false}>
                 <DropdownMenu.Trigger disabled={isBusy}>
                   <button
                     type="button"
                     className={styles.saveMore}
                     disabled={isBusy}
-                    aria-label="More save actions"
+                    aria-label="Calculator actions"
                   >
+                    {isBusy && <Spinner size="1" />}
                     <ChevronDownIcon />
                   </button>
                 </DropdownMenu.Trigger>
@@ -234,20 +223,20 @@ export function NavBar({
                         return;
                       }
 
-                      if (isDirty) {
-                        toast.error('Please save your data first!');
-
-                        return;
-                      }
-
                       if (!rank) {
                         toast.error('No rank calculated yet!');
 
                         return;
                       }
 
+                      // Whatever is on screen has to be stored before the
+                      // submission snapshots it. This replaces the dirty
+                      // check: the question was never "is the form dirty",
+                      // it was "is what I am about to submit what they see".
                       void handleToastUpdates(
-                        publishRankSubmission({ totalPoints, rank }),
+                        beforeSubmit?.().then(() =>
+                          publishRankSubmission({ totalPoints, rank }),
+                        ) ?? publishRankSubmission({ totalPoints, rank }),
                         { success: 'Rank application submitted!' },
                       );
                     }}

--- a/apps/web/app/rank-calculator/[player]/actions/update-player-state-action.ts
+++ b/apps/web/app/rank-calculator/[player]/actions/update-player-state-action.ts
@@ -1,0 +1,79 @@
+'use server';
+
+import { z } from 'zod';
+import { authActionClient } from '@/app/safe-action';
+import { PlayerName } from '@/app/schemas/player';
+import { updatePlayerEditableFields } from '@/lib/db/player-operations';
+import { userDraftRankSubmissionKey } from '@/config/redis';
+import { redis } from '@/redis';
+import { RankCalculatorSchema } from '../submit-rank-calculator-validation';
+
+/**
+ * The fields a player may set for themselves.
+ *
+ * Deliberately a **pick**, not the whole schema. `RankCalculatorSchema` also
+ * carries stats (`ehb`, `totalLevel`, clue counts) that are read-only in the
+ * UI and owned by TempleOSRS/WikiSync, plus `rank` and `points`, which are
+ * decided server-side. None of those may be asserted by the browser — the form
+ * renders them, it does not get a vote on them.
+ */
+export const PlayerEditableSchema = RankCalculatorSchema.pick({
+  acquiredItems: true,
+  achievementDiaries: true,
+  combatAchievementTier: true,
+  tzhaarCape: true,
+  hasBloodTorva: true,
+  hasDizanasQuiver: true,
+  hasRadiantOathplate: true,
+  hasAchievementDiaryCape: true,
+  proofLink: true,
+}).partial();
+
+export type PlayerEditableFields = z.infer<typeof PlayerEditableSchema>;
+
+/**
+ * Persists a change the player just made, as it is made.
+ *
+ * **Partial by design.** `saveDraftRankSubmissionAction`, which this replaces,
+ * took the entire form on every call — which is why every page load rewrote
+ * every field. Autosave sends only what actually changed, so two edits in
+ * different panels can't clobber each other, and a request carries a handful
+ * of keys rather than the whole sheet.
+ */
+export const updatePlayerStateAction = authActionClient
+  .metadata({ actionName: 'update-player-state' })
+  .bindArgsSchemas<[playerName: typeof PlayerName]>([PlayerName])
+  .schema(PlayerEditableSchema)
+  .action(
+    async ({
+      parsedInput,
+      bindArgsParsedInputs: [playerName],
+      ctx: { userId },
+    }) => {
+      await updatePlayerEditableFields(playerName, parsedInput, userId);
+
+      // The Redis draft is no longer read by the calculator — Postgres above is
+      // authoritative — but a rank submission is still a literal `COPY` of it,
+      // so letting it go stale would make members submit sheets that don't
+      // match what they can see.
+      //
+      // Temporary, and the whole reason it is a shim rather than a design: the
+      // next change snapshots submissions from the player record instead, at
+      // which point the draft has no readers left and the key goes.
+      try {
+        const draftKey = userDraftRankSubmissionKey(userId, playerName);
+        const draft = await redis.json.get<Record<string, unknown>>(draftKey);
+
+        if (draft) {
+          await redis.json.set(draftKey, '$', { ...draft, ...parsedInput });
+        }
+      } catch (error) {
+        console.error(
+          `Failed to mirror autosave into the draft for ${playerName}:`,
+          error,
+        );
+      }
+
+      return { success: true };
+    },
+  );

--- a/apps/web/app/rank-calculator/[player]/form-wrapper.tsx
+++ b/apps/web/app/rank-calculator/[player]/form-wrapper.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import { FormProvider } from 'react-hook-form';
-import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hooks';
+import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Rank } from '@/config/enums';
 import { toast } from 'react-toastify';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { RankCalculator } from './rank-calculator';
 import {
   RankCalculatorSchema,
   RankCalculatorValidator,
 } from './submit-rank-calculator-validation';
-import { saveDraftRankSubmissionAction } from './actions/save-draft-rank-submission-action';
-import { handleToastUpdates } from '../utils/handle-toast-updates';
+import {
+  PlayerEditableFields,
+  updatePlayerStateAction,
+} from './actions/update-player-state-action';
+import { useAutosave } from '../hooks/use-autosave';
 import { CurrentPlayerProvider } from '../contexts/current-player-context';
 import { NavBar } from '@/app/components/nav-bar';
 import { Player } from '@/app/schemas/player';
@@ -39,44 +41,41 @@ export function FormWrapper({
   userCalculators,
   warnings,
 }: FormWrapperProps) {
-  const {
-    form,
-    action: {
-      executeAsync: saveDraftRankSubmission,
-      isExecuting,
-      isTransitioning,
+  const form = useForm<Omit<RankCalculatorSchema, 'rank' | 'points'>>({
+    resolver: zodResolver(RankCalculatorValidator),
+    defaultValues: formData,
+    criteriaMode: 'all',
+    mode: 'onBlur',
+  });
+
+  const save = useCallback(
+    async (patch: PlayerEditableFields) => {
+      // Bound args come first: the action is bound to the player name, and
+      // takes the patch as its input.
+      const result = await updatePlayerStateAction(playerName, patch);
+
+      return Boolean(result?.data?.success);
     },
-  } = useHookFormAction(
-    saveDraftRankSubmissionAction,
-    zodResolver(RankCalculatorValidator),
-    {
-      formProps: {
-        defaultValues: formData,
-        criteriaMode: 'all',
-        mode: 'onBlur',
-      },
-    },
+    [playerName],
   );
 
-  // Custom save function with rank validation
-  const submitRankCalculator = form.handleSubmit(async (data) => {
-    try {
-      const result = await handleToastUpdates(saveDraftRankSubmission(data), {
-        pending: 'Saving draft...',
-        success: {
-          render() {
-            form.reset(data, { keepIsSubmitSuccessful: true });
+  // A failed write is the only thing worth interrupting for. Success is
+  // silent — a toast every 800ms would be intolerable, and "your edit
+  // applied" is not news.
+  const onAutosaveError = useCallback(() => {
+    toast.error("Your latest change didn't go through. Retrying…", {
+      toastId: 'autosave-failed',
+    });
+  }, []);
 
-            return 'Draft saved!';
-          },
-        },
-      });
-      return result;
-    } catch (error) {
-      console.error('Save failed:', error);
-      throw error;
-    }
-  });
+  const { flushNow } = useAutosave({ save, onError: onAutosaveError });
+
+  // "Apply for promotion" needs whatever is on screen to be stored first —
+  // which used to be spelled as a dirty check and a "save your data first!"
+  // toast. Now it just waits for the write.
+  const submitRankCalculator = useCallback(async () => {
+    await flushNow();
+  }, [flushNow]);
 
   // Each warning carries a stable `toastId` so it can only ever be on screen
   // once: the effect runs more than once per visit (React re-mounts it in
@@ -137,15 +136,7 @@ export function FormWrapper({
             playerName={playerName}
             userCalculators={userCalculators}
             showSaveActions={true}
-            onSave={() => saveDraftRankSubmission(form.getValues())}
-            isSaving={
-              isExecuting || isTransitioning || form.formState.isSubmitting
-            }
-            canSave={form.formState.isValid}
-            isActionActive={
-              isExecuting || isTransitioning || form.formState.isSubmitting
-            }
-            submitForm={submitRankCalculator}
+            beforeSubmit={flushNow}
           />
           <div style={{ flex: 1 }}>
             <RankCalculator submitRankCalculatorAction={submitRankCalculator} />

--- a/apps/web/app/rank-calculator/hooks/build-player-patch.spec.ts
+++ b/apps/web/app/rank-calculator/hooks/build-player-patch.spec.ts
@@ -1,0 +1,102 @@
+import { buildPlayerPatch } from './use-autosave';
+
+const committed = {
+  playerName: 'Iron Wispy',
+  proofLink: 'https://example.com/proof',
+  hasRadiantOathplate: false,
+  hasBloodTorva: false,
+  combatAchievementTier: 'Hard' as const,
+  tzhaarCape: 'Fire cape' as const,
+  acquiredItems: { 'Abyssal whip': true },
+  achievementDiaries: { Morytania: 'Elite' as const },
+  ehb: 500,
+  totalLevel: 2000,
+};
+
+type Values = Parameters<typeof buildPlayerPatch>[0];
+
+describe('buildPlayerPatch', () => {
+  it('sends nothing when nothing changed', () => {
+    expect(
+      buildPlayerPatch(committed as Values, committed as Values),
+    ).toBeNull();
+  });
+
+  it('sends only the field that changed', () => {
+    expect(
+      buildPlayerPatch(
+        { ...committed, hasRadiantOathplate: true } as Values,
+        committed as Values,
+      ),
+    ).toEqual({ hasRadiantOathplate: true });
+  });
+
+  /**
+   * The whole reason autosave replaced the draft save: that took the entire
+   * form every time, which is why every page load rewrote every field.
+   */
+  it('never sends a field the player does not own', () => {
+    const patch = buildPlayerPatch(
+      { ...committed, ehb: 9999, totalLevel: 2376 } as Values,
+      committed as Values,
+    );
+
+    expect(patch).toBeNull();
+  });
+
+  it('still sends owned fields when unowned ones also moved', () => {
+    expect(
+      buildPlayerPatch(
+        { ...committed, ehb: 9999, proofLink: null } as unknown as Values,
+        committed as Values,
+      ),
+    ).toEqual({ proofLink: null });
+  });
+
+  /**
+   * react-hook-form replaces these objects wholesale on every edit, so an
+   * identity check would report a change on every keystroke.
+   */
+  it('compares object fields structurally, not by identity', () => {
+    expect(
+      buildPlayerPatch(
+        { ...committed, acquiredItems: { 'Abyssal whip': true } } as Values,
+        committed as Values,
+      ),
+    ).toBeNull();
+
+    expect(
+      buildPlayerPatch(
+        {
+          ...committed,
+          acquiredItems: { 'Abyssal whip': true, 'Dragon defender': true },
+        } as Values,
+        committed as Values,
+      ),
+    ).toEqual({
+      acquiredItems: { 'Abyssal whip': true, 'Dragon defender': true },
+    });
+  });
+
+  it('sends a cleared proof link, which is a value and not an absence', () => {
+    expect(
+      buildPlayerPatch(
+        { ...committed, proofLink: '' } as Values,
+        committed as Values,
+      ),
+    ).toEqual({ proofLink: '' });
+  });
+
+  it('sends several changed fields together', () => {
+    expect(
+      buildPlayerPatch(
+        {
+          ...committed,
+          hasBloodTorva: true,
+          combatAchievementTier: 'Master',
+        } as Values,
+        committed as Values,
+      ),
+    ).toEqual({ hasBloodTorva: true, combatAchievementTier: 'Master' });
+  });
+});

--- a/apps/web/app/rank-calculator/hooks/use-autosave.ts
+++ b/apps/web/app/rank-calculator/hooks/use-autosave.ts
@@ -1,0 +1,144 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { debounce } from 'lodash';
+import {
+  PlayerEditableFields,
+  PlayerEditableSchema,
+} from '../[player]/actions/update-player-state-action';
+import { RankCalculatorSchema } from '../[player]/submit-rank-calculator-validation';
+
+/**
+ * How long to wait after the last change before writing.
+ *
+ * Long enough that ticking twenty notable items in a row lands as one request,
+ * short enough that a change is stored well before anyone navigates away.
+ * `mode: 'onBlur'` means validation is already blur-scoped, so there is nothing
+ * to gain from going lower.
+ */
+const debounceMs = 800;
+
+/** Fields the player owns, and so the only ones autosave ever sends. */
+const editableKeys = Object.keys(
+  PlayerEditableSchema.shape,
+) as (keyof PlayerEditableFields)[];
+
+type FormValues = Omit<RankCalculatorSchema, 'rank' | 'points'>;
+
+/**
+ * The changed subset of the player-owned fields, or null if nothing moved.
+ *
+ * Compared against the last values known to be stored rather than against the
+ * form's initial state, so a field edited, reverted, and edited again is still
+ * seen. Exported for its own spec — the diffing is the part worth testing, and
+ * it is pure.
+ */
+export function buildPlayerPatch(
+  values: Partial<FormValues>,
+  committed: Partial<FormValues>,
+): PlayerEditableFields | null {
+  const patch: Record<string, unknown> = {};
+
+  editableKeys.forEach((key) => {
+    const next = values[key as keyof FormValues];
+    const previous = committed[key as keyof FormValues];
+
+    // Structural compare: `acquiredItems` and `achievementDiaries` are objects
+    // that react-hook-form replaces wholesale on every edit, so identity says
+    // nothing.
+    if (JSON.stringify(next) !== JSON.stringify(previous)) {
+      patch[key] = next;
+    }
+  });
+
+  return Object.keys(patch).length > 0 ? (patch as PlayerEditableFields) : null;
+}
+
+interface UseAutosaveOptions {
+  /** Persists a patch. Resolves false if the write did not land. */
+  save: (patch: PlayerEditableFields) => Promise<boolean>;
+  onError: () => void;
+}
+
+/**
+ * Persists the player's edits as they make them.
+ *
+ * There is no save step, and deliberately no save *affordance* either — no
+ * button, no "Saved ✓", no toast on success. An edit applying and staying
+ * applied is the expected case and does not need reporting; the UI only speaks
+ * up when a write fails, which is the one thing the player could not otherwise
+ * know.
+ *
+ * Flushes immediately on tab hide, so a change made and then dismissed is not
+ * lost inside the debounce window.
+ */
+export function useAutosave({ save, onError }: UseAutosaveOptions) {
+  const { watch, getValues } = useFormContext<FormValues>();
+
+  // What we believe is stored. Seeded from the values the server rendered.
+  const committed = useRef<Partial<FormValues>>(getValues());
+  const inFlight = useRef(false);
+
+  const flush = useCallback(async () => {
+    if (inFlight.current) return;
+
+    const patch = buildPlayerPatch(getValues(), committed.current);
+
+    if (!patch) return;
+
+    inFlight.current = true;
+
+    try {
+      const stored = await save(patch);
+
+      if (stored) {
+        // Merge rather than replace: the player may have edited something else
+        // while this request was in flight, and that change is not stored yet.
+        committed.current = { ...committed.current, ...patch };
+      } else {
+        onError();
+      }
+    } catch {
+      onError();
+    } finally {
+      inFlight.current = false;
+    }
+  }, [getValues, save, onError]);
+
+  // Memoised so the debounce is created once. Built inline it would be a new
+  // timer on every render, which debounces nothing.
+  const scheduleFlush = useMemo(
+    () => debounce(() => void flush(), debounceMs),
+    [flush],
+  );
+
+  useEffect(() => {
+    const subscription = watch(() => scheduleFlush());
+
+    return () => subscription.unsubscribe();
+  }, [watch, scheduleFlush]);
+
+  useEffect(() => {
+    const onHidden = () => {
+      if (document.visibilityState === 'hidden') {
+        scheduleFlush.flush();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onHidden);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onHidden);
+      scheduleFlush.flush();
+    };
+  }, [scheduleFlush]);
+
+  /** Forces any pending change out now — used before applying for a rank. */
+  const flushNow = useCallback(async () => {
+    scheduleFlush.cancel();
+    await flush();
+  }, [scheduleFlush, flush]);
+
+  return { flushNow };
+}

--- a/apps/web/lib/db/item-override-operations.ts
+++ b/apps/web/lib/db/item-override-operations.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { db } from './index';
 import { playerItemOverrides } from './schema';
 
@@ -103,4 +103,44 @@ export async function getItemOverrides(
     (acc, { itemName, isAcquired }) => ({ ...acc, [itemName]: isAcquired }),
     {},
   );
+}
+
+/**
+ * Records the player's answer for specific items, leaving every other override
+ * alone.
+ *
+ * Autosave's counterpart to {@link syncItemOverrides}. It cannot compute the
+ * sparse diff, because it has no idea what the data sources derive — that is
+ * only known inside `fetchPlayerDetails`, which has just talked to WikiSync and
+ * Temple. So it stores the answer as given, for the handful of items that
+ * actually changed, and the next sync reconciles: `syncItemOverrides` drops any
+ * row a source has since explained.
+ *
+ * The upshot is that an override may be redundant for a few minutes, until the
+ * player next loads the calculator. Redundant is harmless; lost is not.
+ */
+export async function upsertItemOverrides(
+  playerName: string,
+  answers: Record<string, boolean>,
+): Promise<number> {
+  const rows = Object.entries(answers).map(([itemName, isAcquired]) => ({
+    playerName,
+    itemName,
+    isAcquired,
+  }));
+
+  if (rows.length === 0) return 0;
+
+  await db
+    .insert(playerItemOverrides)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: [playerItemOverrides.playerName, playerItemOverrides.itemName],
+      set: {
+        isAcquired: sql`excluded.is_acquired`,
+        updatedAt: new Date(),
+      },
+    });
+
+  return rows.length;
 }

--- a/apps/web/lib/db/player-operations.ts
+++ b/apps/web/lib/db/player-operations.ts
@@ -15,6 +15,7 @@ import {
 } from './schema';
 import { getCategoryFromItemName } from './item-mapping-utils';
 import { calculatePlayerPoints } from '@/app/rank-calculator/utils/calculate-player-points';
+import { upsertItemOverrides } from './item-override-operations';
 import { syncPlayerAccomplishments } from './accomplishment-operations';
 import type { PlayerDetailsResponse } from '@/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details';
 import { TempleOSRSCollectionLogItem } from '@/app/schemas/temple-api';
@@ -856,5 +857,73 @@ export async function processPlayerData(
   } catch (error) {
     console.error(`Failed to process player data for ${playerName}:`, error);
     throw error; // Re-throw to let calling code handle the error appropriately
+  }
+}
+
+/**
+ * Writes a change the player made to their own sheet.
+ *
+ * The autosave path. Everything here is a field the player owns outright or
+ * claims for themselves — see `PlayerEditableSchema`, which is what constrains
+ * the caller. Stats, rank and points are absent by construction: they are
+ * derived or come from a data source, and the browser does not get a vote.
+ *
+ * Partial: only the keys actually supplied are touched. That is what lets two
+ * edits in different panels land independently instead of each rewriting the
+ * whole record.
+ */
+export async function updatePlayerEditableFields(
+  playerName: string,
+  fields: {
+    // `pickBy` in the zod transform leaves the value type optional.
+    acquiredItems?: Record<string, boolean | undefined>;
+    achievementDiaries?: Record<string, string>;
+    combatAchievementTier?: string;
+    tzhaarCape?: string;
+    hasBloodTorva?: boolean;
+    hasDizanasQuiver?: boolean;
+    hasRadiantOathplate?: boolean;
+    hasAchievementDiaryCape?: boolean;
+    proofLink?: string | null;
+  },
+  discordUserId: string,
+): Promise<void> {
+  await assertDiscordOwnership(playerName, discordUserId);
+
+  const { acquiredItems, achievementDiaries, proofLink, ...scalars } = fields;
+
+  const updateData: Partial<UpdatePlayerData> = { ...scalars };
+
+  // `proofLink` is separated out because null and '' are real values here —
+  // the player clearing their link — and must not be mistaken for "unset".
+  if (proofLink !== undefined) updateData.proofLink = proofLink;
+
+  if (Object.keys(updateData).length > 0) {
+    await updatePlayer(playerName, updateData, discordUserId);
+  }
+
+  if (achievementDiaries) {
+    await Promise.all(
+      Object.entries(achievementDiaries).map(([location, tier]) =>
+        createOrUpdateAchievementDiary({
+          playerName,
+          location,
+          tier,
+          completed: tier !== 'None',
+        }),
+      ),
+    );
+  }
+
+  if (acquiredItems) {
+    const answers = Object.fromEntries(
+      Object.entries(acquiredItems)
+        .filter(([, value]) => value !== undefined)
+        .map(([itemName, value]) => [itemName, Boolean(value)]),
+    );
+
+    if (Object.keys(answers).length > 0) {
+      await upsertItemOverrides(playerName, answers);
+    }
   }
 }


### PR DESCRIPTION
<!-- member-summary:start -->
The rank calculator now saves your changes automatically as you make them — there's no Save button any more, and nothing to remember to click before applying for a rank.
<!-- member-summary:end -->

The headline change. **There is no Save button, no "Saved ✓", no success toast.** An edit applying and staying applied is the expected case and doesn't need reporting; the only UI is on failure, which is the one thing a member couldn't otherwise know.

## What went

| Removed | Where |
|---|---|
| The **Save** button | `nav-bar.tsx` |
| **"Please save your data first!"** on Apply | `nav-bar.tsx` |
| `onSave` / `canSave` / `isSaving` props | `NavBarProps` |
| `isDirty` as a gate on anything but "Reset form defaults" | `nav-bar.tsx` |
| "Saving draft…" / "Draft saved!" toasts | `form-wrapper.tsx` |
| `useHookFormAction` bound to the save action | `form-wrapper.tsx` |

"Apply for promotion" no longer asks whether the form is dirty — it awaits a flush. **The question was never "is the form dirty", it was "is what I'm about to submit what they can see"**, and waiting for the write answers that directly.

## What arrived

**`updatePlayerStateAction` takes a partial patch**, and its schema is a `pick` of `RankCalculatorSchema`. Stats, `rank` and `points` are absent *by construction* — the browser cannot assert them even if it tried. The action it replaces took the entire form on every call, which is why every page load rewrote every field.

**`useAutosave`** watches the form and diffs against what's known to be stored, rather than the form's initial state, so a field edited → reverted → edited again is still seen. Debounced 800ms so ticking twenty notable items lands as one request; flushes on tab hide and before a submission.

## The one subtle bit: item overrides

Autosave **cannot** compute the sparse override diff, because it has no idea what the sources derive — that's only known inside `fetchPlayerDetails`, which has just talked to WikiSync and Temple.

So `upsertItemOverrides` stores the player's answer as given, for the items that actually changed, and the next sync reconciles: `syncItemOverrides` drops any row a source has since explained. An override may be redundant for a few minutes until the next page load. **Redundant is harmless; lost is not.**

## ⚠️ The Redis draft is still written, and it's a shim

Nothing reads it for the calculator any more — Postgres is authoritative. But a rank submission is still a literal Redis `COPY` **of the draft**, so letting it go stale would have members submitting sheets that don't match their screen.

`updatePlayerStateAction` therefore mirrors each patch into it. That's temporary and labelled as such: the next change snapshots submissions from the player record, at which point the draft has no readers and `userDraftRankSubmissionKey` goes.

## Tested

- **7 hermetic specs on `buildPlayerPatch`** — the pure diffing, which is the part worth testing. Covers: nothing changed, one field changed, structural comparison of `acquiredItems` (react-hook-form replaces those objects wholesale, so identity comparison would fire on every keystroke), a cleared proof link as a *value* rather than an absence, and — the important one — **a stat moving produces no patch at all**.
- Both typecheck projects clean.
- Full Jest suite diffed against `main`: only addition is the new passing suite.
- Grepped the player-facing calculator for save wording; what's left is a doc comment and an unrelated dialog's internal loading state.

**Not verified, and this is the significant gap:** none of the autosave behaviour has been exercised in a browser. The calculator is Discord-auth-gated, so the debounce, the flush-on-hide, the failure toast, and the Apply-waits-for-flush path have all been reasoned through and typechecked but not *used*. Worth a real pass before this goes near members — particularly: tick an item, reload, confirm it stuck; and apply for a rank immediately after an edit, confirming the submission reflects it.

Unrelated: `yarn prettier --check` flags four `point-calculator` files as unformatted across the whole app. They're pre-existing and I deliberately kept them out of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)