### PR TITLE
Fix two crashes in the calculator's autosave

### DIFF
--- a/apps/web/app/rank-calculator/[player]/actions/update-player-state-action.ts
+++ b/apps/web/app/rank-calculator/[player]/actions/update-player-state-action.ts
@@ -1,33 +1,9 @@
 'use server';
 
-import { z } from 'zod';
 import { authActionClient } from '@/app/safe-action';
 import { PlayerName } from '@/app/schemas/player';
 import { updatePlayerEditableFields } from '@/lib/db/player-operations';
-import { RankCalculatorSchema } from '../submit-rank-calculator-validation';
-
-/**
- * The fields a player may set for themselves.
- *
- * Deliberately a **pick**, not the whole schema. `RankCalculatorSchema` also
- * carries stats (`ehb`, `totalLevel`, clue counts) that are read-only in the
- * UI and owned by TempleOSRS/WikiSync, plus `rank` and `points`, which are
- * decided server-side. None of those may be asserted by the browser — the form
- * renders them, it does not get a vote on them.
- */
-export const PlayerEditableSchema = RankCalculatorSchema.pick({
-  acquiredItems: true,
-  achievementDiaries: true,
-  combatAchievementTier: true,
-  tzhaarCape: true,
-  hasBloodTorva: true,
-  hasDizanasQuiver: true,
-  hasRadiantOathplate: true,
-  hasAchievementDiaryCape: true,
-  proofLink: true,
-}).partial();
-
-export type PlayerEditableFields = z.infer<typeof PlayerEditableSchema>;
+import { PlayerEditableSchema } from '../player-editable-schema';
 
 /**
  * Persists a change the player just made, as it is made.

--- a/apps/web/app/rank-calculator/[player]/form-wrapper.tsx
+++ b/apps/web/app/rank-calculator/[player]/form-wrapper.tsx
@@ -10,10 +10,8 @@ import {
   RankCalculatorSchema,
   RankCalculatorValidator,
 } from './submit-rank-calculator-validation';
-import {
-  PlayerEditableFields,
-  updatePlayerStateAction,
-} from './actions/update-player-state-action';
+import { updatePlayerStateAction } from './actions/update-player-state-action';
+import { PlayerEditableFields } from './player-editable-schema';
 import { useAutosave } from '../hooks/use-autosave';
 import { CurrentPlayerProvider } from '../contexts/current-player-context';
 import { NavBar } from '@/app/components/nav-bar';
@@ -68,7 +66,11 @@ export function FormWrapper({
     });
   }, []);
 
-  const { flushNow } = useAutosave({ save, onError: onAutosaveError });
+  const { flushNow } = useAutosave({
+    form,
+    save,
+    onError: onAutosaveError,
+  });
 
   // "Apply for promotion" needs whatever is on screen to be stored first —
   // which used to be spelled as a dirty check and a "save your data first!"

--- a/apps/web/app/rank-calculator/[player]/player-editable-schema.ts
+++ b/apps/web/app/rank-calculator/[player]/player-editable-schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { RankCalculatorSchema } from './submit-rank-calculator-validation';
+
+/**
+ * The fields a player may set for themselves.
+ *
+ * Deliberately a **pick**, not the whole schema. `RankCalculatorSchema` also
+ * carries stats (`ehb`, `totalLevel`, clue counts) that are read-only in the UI
+ * and owned by TempleOSRS/WikiSync, plus `rank` and `points`, which are decided
+ * server-side. None of those may be asserted by the browser — the form renders
+ * them, it does not get a vote on them.
+ *
+ * ⚠️ **This lives in its own module, not beside the action that validates
+ * with it.** A `'use server'` file may only export async functions; Next strips
+ * everything else from the client bundle, so importing this from there gave the
+ * autosave hook `undefined` and `Object.keys(undefined)` threw on page load.
+ * Anything both the client and a server action need has to sit outside the
+ * action module.
+ */
+export const PlayerEditableSchema = RankCalculatorSchema.pick({
+  acquiredItems: true,
+  achievementDiaries: true,
+  combatAchievementTier: true,
+  tzhaarCape: true,
+  hasBloodTorva: true,
+  hasDizanasQuiver: true,
+  hasRadiantOathplate: true,
+  hasAchievementDiaryCape: true,
+  proofLink: true,
+}).partial();
+
+export type PlayerEditableFields = z.infer<typeof PlayerEditableSchema>;

--- a/apps/web/app/rank-calculator/hooks/use-autosave.spec.tsx
+++ b/apps/web/app/rank-calculator/hooks/use-autosave.spec.tsx
@@ -1,0 +1,106 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { useAutosave } from './use-autosave';
+import { PlayerEditableSchema } from '../[player]/player-editable-schema';
+
+/**
+ * Two regressions, both of which shipped and both of which only appear when the
+ * page is actually rendered — a typecheck and a production build passed over
+ * each of them.
+ *
+ * 1. `PlayerEditableSchema` was exported from a `'use server'` module. Next
+ *    only keeps async function exports from those, so in the browser it was
+ *    `undefined` and `Object.keys(undefined)` threw at import time.
+ * 2. `useAutosave` read the form from `useFormContext()`, but it is called by
+ *    the component that *renders* `<FormProvider>` — so there was no provider
+ *    above it and the context was null.
+ *
+ * Neither needs a database or a logged-in session to catch, which is the point
+ * of putting them here.
+ */
+describe('useAutosave', () => {
+  it('has a schema to derive its field list from', () => {
+    // Guards regression 1: if this module ever moves back behind 'use server',
+    // `.shape` is undefined here exactly as it was in the browser.
+    expect(PlayerEditableSchema?.shape).toBeDefined();
+    expect(Object.keys(PlayerEditableSchema.shape).length).toBeGreaterThan(0);
+  });
+
+  it('mounts without a FormProvider above it', () => {
+    // Guards regression 2. The hook is called by the form's owner, so there is
+    // deliberately no provider here — mirroring FormWrapper.
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { proofLink: '' } });
+
+      return useAutosave({
+        form: form as never,
+        save: jest.fn().mockResolvedValue(true),
+        onError: jest.fn(),
+      });
+    });
+
+    expect(result.current.flushNow).toBeInstanceOf(Function);
+  });
+
+  it('sends nothing when nothing has changed', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { proofLink: 'https://a.test' } });
+
+      return useAutosave({ form: form as never, save, onError: jest.fn() });
+    });
+
+    await result.current.flushNow();
+
+    await waitFor(() => {
+      expect(save).not.toHaveBeenCalled();
+    });
+  });
+
+  it('sends a patch once a player-owned field changes', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    let setValue: (name: never, value: never) => void = jest.fn();
+
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { proofLink: 'https://a.test' } });
+
+      setValue = form.setValue as never;
+
+      return useAutosave({ form: form as never, save, onError: jest.fn() });
+    });
+
+    setValue('proofLink' as never, 'https://b.test' as never);
+
+    await result.current.flushNow();
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith({ proofLink: 'https://b.test' });
+    });
+  });
+
+  it('reports a write that did not land', async () => {
+    const onError = jest.fn();
+    let setValue: (name: never, value: never) => void = jest.fn();
+
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { proofLink: '' } });
+
+      setValue = form.setValue as never;
+
+      return useAutosave({
+        form: form as never,
+        save: jest.fn().mockResolvedValue(false),
+        onError,
+      });
+    });
+
+    setValue('proofLink' as never, 'https://b.test' as never);
+
+    await result.current.flushNow();
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/app/rank-calculator/hooks/use-autosave.ts
+++ b/apps/web/app/rank-calculator/hooks/use-autosave.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useFormContext } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { debounce } from 'lodash';
 import {
   PlayerEditableFields,
   PlayerEditableSchema,
-} from '../[player]/actions/update-player-state-action';
+} from '../[player]/player-editable-schema';
 import { RankCalculatorSchema } from '../[player]/submit-rank-calculator-validation';
 
 /**
@@ -56,6 +56,16 @@ export function buildPlayerPatch(
 }
 
 interface UseAutosaveOptions {
+  /**
+   * The form itself, passed in rather than pulled from context.
+   *
+   * This hook is called by the component that *renders* `<FormProvider>`, so
+   * at the point it runs there is no provider above it and `useFormContext()`
+   * is null. Taking the instance is not just a workaround — the owner of the
+   * form is the right caller, and a descendant reaching for autosave through
+   * context would be a second writer.
+   */
+  form: UseFormReturn<FormValues>;
   /** Persists a patch. Resolves false if the write did not land. */
   save: (patch: PlayerEditableFields) => Promise<boolean>;
   onError: () => void;
@@ -73,8 +83,8 @@ interface UseAutosaveOptions {
  * Flushes immediately on tab hide, so a change made and then dismissed is not
  * lost inside the debounce window.
  */
-export function useAutosave({ save, onError }: UseAutosaveOptions) {
-  const { watch, getValues } = useFormContext<FormValues>();
+export function useAutosave({ form, save, onError }: UseAutosaveOptions) {
+  const { watch, getValues } = form;
 
   // What we believe is stored. Seeded from the values the server rendered.
   const committed = useRef<Partial<FormValues>>(getValues());


### PR DESCRIPTION
<!-- member-summary:start -->
Fixes a crash that stopped the rank calculator loading.
<!-- member-summary:end -->

**The calculator is broken on `main` right now.** Both bugs shipped in #90.

## 1. A zod schema exported from a `'use server'` module

```
TypeError: can't convert undefined to object
  at use-autosave.ts:23 — Object.keys(PlayerEditableSchema.shape)
```

`PlayerEditableSchema` lived beside the action that validates with it. Next only keeps **async function exports** from a `'use server'` file, so in the client bundle the zod object was `undefined` and `.shape` threw at import time.

Moved to `player-editable-schema.ts`, which both the action and the client import. I audited every other `'use server'` file for non-function value exports — the rest are `export type` / `export interface`, which are erased at compile time and harmless.

## 2. `useFormContext()` called above its own provider

```
TypeError: useFormContext() is null
  at use-autosave.ts:77
```

`useAutosave` pulled the form from context, but it's called by `FormWrapper` — **the component that renders `<FormProvider>`**. At that point there is no provider above it.

It now takes the form instance as an argument. That isn't a workaround: the owner of the form is the right caller, and a descendant reaching for autosave through context would be a second writer racing the first.

## Why these got through, and what stops the next one

I flagged #90 as "not verified in a browser" because the calculator is Discord-auth-gated. That was true but insufficient — **both of these were catchable without a browser, a database or a session.** There simply was no test that rendered the hook at all, so nothing exercised import-time or render-time behaviour. `yarn check-types` and `yarn build` both pass on the broken code.

`use-autosave.spec.tsx` now renders it the way `FormWrapper` does, with no provider above, and asserts the schema has a usable `.shape`. It also covers a patch being sent and a failed write being reported.

**I verified the guard rather than assuming it:** reintroducing the context bug fails four of the five tests; restoring the fix makes them green.

## Tested

- 5 new specs, and the guard proven against the actual bug.
- Both typecheck projects clean; `yarn build` completes.
- Full Jest suite diffed against `main`: only addition is the new suite.
- eslint and prettier clean.

**Still not verified:** the autosave *behaviour* — debounce timing, flush on tab hide, the Apply-waits-for-flush path — needs a real session. What's proven here is that the page renders and the hook works; the parts that need a logged-in browser still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)