### PR TITLE
Give the six unlogged notable items a home

### DIFF
--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/fetch-player-details.ts
@@ -41,6 +41,12 @@ import {
   syncItemOverrides,
 } from '@/lib/db/item-override-operations';
 import {
+  getDerivedItems,
+  syncDerivedItems,
+} from '@/lib/db/derived-item-operations';
+import { getSourceDerivedItemNames } from '@/app/rank-calculator/utils/get-source-derived-item-names';
+import { resolveDerivedItemWrite } from './utils/resolve-derived-item-write';
+import {
   resolveTempleAccountType,
   TempleOSRSCollectionLogItem,
 } from '@/app/schemas/temple-api';
@@ -314,10 +320,35 @@ export async function fetchPlayerDetails(
     // and they are written back further down.
     const storedOverrides = await getItemOverrides(playerRecord.playerName);
 
+    /**
+     * The floor under the six notable items nothing logs.
+     *
+     * They are settled purely by WikiSync, so when WikiSync is unreachable
+     * `isItemAcquired` returns false for every one of them — and, unlike a
+     * collection log item, there is no second source and no logged copy to
+     * recover them from. Before `player_derived_items` existed that silently
+     * subtracted up to 480 points from the stored total and left no trace,
+     * which is the same hazard `currentDbValues` guards for the scalars: an
+     * unreachable source says *nothing*, not no.
+     *
+     * Applied only when WikiSync did not answer. When it did, its answer is
+     * authoritative and is written back below — otherwise a stale `true` would
+     * outlive the thing it described.
+     */
+    const storedDerivedItems = wikiSyncData
+      ? {}
+      : await getDerivedItems(playerRecord.playerName);
+
     const previouslyAcquiredItems = Object.keys({
       ...storedOverrides,
+      ...storedDerivedItems,
       ...(savedData?.acquiredItems ?? {}),
-    }).filter((key) => savedData?.acquiredItems?.[key] ?? storedOverrides[key]);
+    }).filter(
+      (key) =>
+        savedData?.acquiredItems?.[key] ??
+        storedOverrides[key] ??
+        storedDerivedItems[key],
+    );
 
     const allCurrentNotableItemNames = new Set(
       Object.values(itemList)
@@ -538,6 +569,32 @@ export async function fetchPlayerDetails(
         });
       } catch (error) {
         console.error('Failed to sync notable item overrides:', error);
+      }
+
+      // Give the unlogged items their home.
+      //
+      // `acquiredItems` rather than `acquiredItemsMap` — this records what the
+      // *source* said, not what the merge concluded, or a player's own tick
+      // would come back next sync wearing a source's authority. Music cape is
+      // settled by WikiSync's music tracks rather than by `isItemAcquired`, so
+      // it is added here the same way it is added to the map above.
+      //
+      // Whether to write at all is `resolveDerivedItemWrite`'s decision, not a
+      // condition here — see its note.
+      try {
+        const answers = resolveDerivedItemWrite({
+          itemNames: getSourceDerivedItemNames(itemList),
+          sourceAnswered: !!wikiSyncData,
+          sourceItems: hasMusicCape
+            ? [...acquiredItems, 'Music cape']
+            : acquiredItems,
+        });
+
+        if (answers) {
+          await syncDerivedItems(playerRecord.playerName, answers);
+        }
+      } catch (error) {
+        console.error('Failed to sync source-derived items:', error);
       }
     }
 

--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/utils/resolve-derived-item-write.spec.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/utils/resolve-derived-item-write.spec.ts
@@ -1,0 +1,73 @@
+import { resolveDerivedItemWrite } from './resolve-derived-item-write';
+
+const itemNames = ['Quest cape', 'Music cape', '6 Jads'];
+
+describe('resolveDerivedItemWrite', () => {
+  it('records what the source said, item by item', () => {
+    expect(
+      resolveDerivedItemWrite({
+        itemNames,
+        sourceAnswered: true,
+        sourceItems: ['Quest cape', '6 Jads'],
+      }),
+    ).toEqual({
+      'Quest cape': true,
+      'Music cape': false,
+      '6 Jads': true,
+    });
+  });
+
+  it('writes nothing at all when the source did not answer', () => {
+    // The one that matters. An unreachable WikiSync reports no items, which is
+    // indistinguishable from a member having none — persisting it would
+    // overwrite six good answers with false and make the outage permanent.
+    expect(
+      resolveDerivedItemWrite({
+        itemNames,
+        sourceAnswered: false,
+        sourceItems: [],
+      }),
+    ).toBeNull();
+  });
+
+  it('still writes nothing when a silent source happens to be believable', () => {
+    // Guards against "it answered, it just said nothing" — the caller decides
+    // whether the source spoke, and an empty list is never that evidence.
+    expect(
+      resolveDerivedItemWrite({
+        itemNames,
+        sourceAnswered: false,
+        sourceItems: ['Quest cape'],
+      }),
+    ).toBeNull();
+  });
+
+  it('records a genuine negative when the source did answer', () => {
+    // The mirror of the above: an answering source that reports nothing is a
+    // real "they have none", and has to be stored as such or an item a member
+    // has since lost would stick forever.
+    expect(
+      resolveDerivedItemWrite({
+        itemNames,
+        sourceAnswered: true,
+        sourceItems: [],
+      }),
+    ).toEqual({
+      'Quest cape': false,
+      'Music cape': false,
+      '6 Jads': false,
+    });
+  });
+
+  it('ignores items outside the unlogged set', () => {
+    // `sourceItems` is the whole derived notable-item list, most of which is
+    // collection log slots that already have a home.
+    expect(
+      resolveDerivedItemWrite({
+        itemNames: ['Quest cape'],
+        sourceAnswered: true,
+        sourceItems: ['Quest cape', 'Twisted bow', 'Scythe of vitur'],
+      }),
+    ).toEqual({ 'Quest cape': true });
+  });
+});

--- a/apps/web/app/rank-calculator/data-sources/fetch-player-details/utils/resolve-derived-item-write.ts
+++ b/apps/web/app/rank-calculator/data-sources/fetch-player-details/utils/resolve-derived-item-write.ts
@@ -1,0 +1,44 @@
+export interface ResolveDerivedItemWriteInput {
+  /** The notable items nothing logs — `getSourceDerivedItemNames`. */
+  itemNames: string[];
+  /**
+   * Whether the deriving source answered at all this run. This is the whole
+   * point of the function: see the note below.
+   */
+  sourceAnswered: boolean;
+  /** The items the source reported. Meaningless when it did not answer. */
+  sourceItems: Iterable<string>;
+}
+
+/**
+ * What to record about the unlogged items after a sync — and whether to record
+ * anything at all.
+ *
+ * `null` means **write nothing**. That is not a detail: the six items this
+ * covers are settled purely by WikiSync, so a failed read produces an empty
+ * `sourceItems` that is indistinguishable from a member genuinely having none
+ * of them. Persisting that would overwrite six good `true`s with `false` and
+ * turn a temporary outage into a permanent one, which is the precise failure
+ * `player_derived_items` was added to prevent.
+ *
+ * The guard lives in here rather than as an `if` at the call site because an
+ * `if` at a call site is one careless edit from being deleted, and the damage
+ * would be silent — the member simply scores up to 480 points less, and
+ * nothing records that they ever scored more.
+ */
+export function resolveDerivedItemWrite({
+  itemNames,
+  sourceAnswered,
+  sourceItems,
+}: ResolveDerivedItemWriteInput): Record<string, boolean> | null {
+  if (!sourceAnswered) {
+    return null;
+  }
+
+  const reported = new Set(sourceItems);
+
+  return itemNames.reduce<Record<string, boolean>>(
+    (acc, itemName) => ({ ...acc, [itemName]: reported.has(itemName) }),
+    {},
+  );
+}

--- a/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
+++ b/apps/web/app/rank-calculator/players/edit/[player]/actions/edit-player-action.ts
@@ -19,6 +19,7 @@ import {
   playerRankUps,
   playerAccomplishments,
   playerItemOverrides,
+  playerDerivedItems,
 } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
@@ -122,6 +123,14 @@ export const editPlayerAction = authActionClient
             .update(playerItemOverrides)
             .set({ playerName: maybeFormattedPlayerName })
             .where(eq(playerItemOverrides.playerName, previousPlayerName));
+
+          // The unlogged items follow the name for the same reason. Strand
+          // them and the renamed player has no floor under those six until
+          // WikiSync next answers — which is exactly when it matters.
+          await tx
+            .update(playerDerivedItems)
+            .set({ playerName: maybeFormattedPlayerName })
+            .where(eq(playerDerivedItems.playerName, previousPlayerName));
         });
       } else {
         // No name change, just update the player record

--- a/apps/web/app/rank-calculator/utils/get-source-derived-item-names.spec.ts
+++ b/apps/web/app/rank-calculator/utils/get-source-derived-item-names.spec.ts
@@ -1,0 +1,49 @@
+import { itemList } from '@/data/item-list';
+import { ItemCategoryMap } from '@/app/schemas/items';
+import { getSourceDerivedItemNames } from './get-source-derived-item-names';
+
+describe('getSourceDerivedItemNames', () => {
+  it('picks out exactly the items no collection log records', () => {
+    // The real list, because the point of this function is what it says about
+    // *our* data. If someone adds a quest or manual item, this list grows and
+    // the test says so — which is the reminder that the new item needs a home
+    // in `player_derived_items` too.
+    expect(getSourceDerivedItemNames(itemList).sort()).toEqual(
+      [
+        '6 Jads',
+        'Barrows gloves',
+        'Book of the dead',
+        'Mage Arena 2 cape',
+        'Music cape',
+        'Quest cape',
+      ],
+    );
+  });
+
+  it('leaves every collection log item out', () => {
+    const derived = new Set(
+      getSourceDerivedItemNames(itemList),
+    );
+
+    // A clog item already has a durable copy in `player_acquired_items`;
+    // duplicating it here would give one item two homes that could disagree.
+    expect(derived.has('Twisted bow')).toBe(false);
+    expect(derived.has('Scythe of vitur')).toBe(false);
+  });
+
+  it('keys items the way the form does', () => {
+    // `stripEntityName` drops apostrophes and full stops. The keys have to
+    // match `acquiredItems` exactly or the floor lands under a name nothing
+    // ever looks up.
+    const derived = getSourceDerivedItemNames({
+      test: {
+        items: [
+          { name: "Dizana's quiver", image: 'x', points: 1 },
+          { name: 'Plain', image: 'x', points: 1 },
+        ],
+      },
+    } as unknown as ItemCategoryMap);
+
+    expect(derived).toEqual(['Dizanas quiver', 'Plain']);
+  });
+});

--- a/apps/web/app/rank-calculator/utils/get-source-derived-item-names.ts
+++ b/apps/web/app/rank-calculator/utils/get-source-derived-item-names.ts
@@ -1,0 +1,25 @@
+import { ItemCategoryMap, isCollectionLogItem } from '@/app/schemas/items';
+import { stripEntityName } from './strip-entity-name';
+
+/**
+ * The notable items no collection log records.
+ *
+ * Everything else in the list is a collection log slot, and a slot is durable:
+ * `player_acquired_items` keeps a copy, so it can be re-read when a source is
+ * quiet. These cannot be, because nothing logs them — they are settled by a
+ * live WikiSync read of the player's quests, combat achievements and music
+ * tracks, which is why they need `player_derived_items` to have a home at all.
+ *
+ * Derived from the list rather than named, so a new `questItem` or
+ * `manualItem` is picked up without anyone remembering to update a constant.
+ * As of writing it resolves to six: Barrows gloves, Book of the dead, Quest
+ * cape, Mage Arena 2 cape, 6 Jads and Music cape.
+ */
+export function getSourceDerivedItemNames(
+  notableItemList: ItemCategoryMap,
+): string[] {
+  return Object.values(notableItemList)
+    .flatMap(({ items }) => items)
+    .filter((item) => !isCollectionLogItem(item))
+    .map(({ name }) => stripEntityName(name));
+}

--- a/apps/web/drizzle/0023_plain_peter_parker.sql
+++ b/apps/web/drizzle/0023_plain_peter_parker.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "player_derived_items" (
+	"player_name" varchar(12) NOT NULL,
+	"item_name" text NOT NULL,
+	"is_acquired" boolean NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "player_derived_items_player_name_item_name_pk" PRIMARY KEY("player_name","item_name")
+);

--- a/apps/web/drizzle/meta/0023_snapshot.json
+++ b/apps/web/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1006 @@
+{
+  "id": "704d5936-8f8a-4d2d-8990-2b199cecf4da",
+  "prevId": "b7e85f14-feee-46c1-97f7-dc9174d2eafd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.player_accomplishments": {
+      "name": "player_accomplishments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "accomplishment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accomplishment_key": {
+          "name": "accomplishment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_accomplishments_achieved_at_idx": {
+          "name": "player_accomplishments_achieved_at_idx",
+          "columns": [
+            {
+              "expression": "achieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_accomplishments_player_name_accomplishment_key_unique": {
+          "name": "player_accomplishments_player_name_accomplishment_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "accomplishment_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_achievement_diaries": {
+      "name": "player_achievement_diaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_acquired_items": {
+      "name": "player_acquired_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_category": {
+          "name": "item_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_first_logged": {
+          "name": "date_first_logged",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_acquired_items_item_id_idx": {
+          "name": "player_acquired_items_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_acquired_items_player_name_item_id_unique": {
+          "name": "player_acquired_items_player_name_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_name",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_derived_items": {
+      "name": "player_derived_items",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_acquired": {
+          "name": "is_acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_derived_items_player_name_item_name_pk": {
+          "name": "player_derived_items_player_name_item_name_pk",
+          "columns": [
+            "player_name",
+            "item_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_item_overrides": {
+      "name": "player_item_overrides",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_acquired": {
+          "name": "is_acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_item_overrides_player_name_item_name_pk": {
+          "name": "player_item_overrides_player_name_item_name_pk",
+          "columns": [
+            "player_name",
+            "item_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_rank_ups": {
+      "name": "player_rank_ups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "old_rank": {
+          "name": "old_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_rank": {
+          "name": "new_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ehb": {
+          "name": "ehb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ehp": {
+          "name": "ehp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_achievement_tier": {
+          "name": "combat_achievement_tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_link": {
+          "name": "proof_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_log_count": {
+          "name": "collection_log_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_total": {
+          "name": "collection_log_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_level": {
+          "name": "total_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 32
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1154
+        },
+        "clue_count_beginner": {
+          "name": "clue_count_beginner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_easy": {
+          "name": "clue_count_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_medium": {
+          "name": "clue_count_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_hard": {
+          "name": "clue_count_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_elite": {
+          "name": "clue_count_elite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clue_count_master": {
+          "name": "clue_count_master",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tzhaar_cape": {
+          "name": "tzhaar_cape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'None'"
+        },
+        "has_blood_torva": {
+          "name": "has_blood_torva",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_radiant_oathplate": {
+          "name": "has_radiant_oathplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_dizanas_quiver": {
+          "name": "has_dizanas_quiver",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_achievement_diary_cape": {
+          "name": "has_achievement_diary_cape",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "combat_bonus_points": {
+          "name": "combat_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skilling_bonus_points": {
+          "name": "skilling_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_log_bonus_points": {
+          "name": "collection_log_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notable_items_bonus_points": {
+          "name": "notable_items_bonus_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mobile_only": {
+          "name": "is_mobile_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "staff_role": {
+          "name": "staff_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gim_group_name": {
+          "name": "gim_group_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_player_name_lower_unique": {
+          "name": "players_player_name_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"player_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_submissions": {
+      "name": "rank_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_discord_id": {
+          "name": "submitted_by_discord_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_rank": {
+          "name": "previous_rank",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "rank_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "actioned_by_discord_id": {
+          "name": "actioned_by_discord_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actioned_at": {
+          "name": "actioned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_automatic": {
+          "name": "is_automatic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_temple_player_stats": {
+          "name": "has_temple_player_stats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_temple_collection_log": {
+          "name": "has_temple_collection_log",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_wikisync_data": {
+          "name": "has_wikisync_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_temple_collection_log_outdated": {
+          "name": "is_temple_collection_log_outdated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rank_submissions_player_name_idx": {
+          "name": "rank_submissions_player_name_idx",
+          "columns": [
+            {
+              "expression": "player_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_submissions_status_submitted_at_idx": {
+          "name": "rank_submissions_status_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_submissions_discord_message_id_unique": {
+          "name": "rank_submissions_discord_message_id_unique",
+          "columns": [
+            {
+              "expression": "discord_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_role_changes": {
+      "name": "staff_role_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_role": {
+          "name": "old_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_role": {
+          "name": "new_role",
+          "type": "staff_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_player_name": {
+          "name": "changed_by_player_name",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by_discord_user_id": {
+          "name": "changed_by_discord_user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "staff_role_changes_player_name_idx": {
+          "name": "staff_role_changes_player_name_idx",
+          "columns": [
+            {
+              "expression": "player_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.accomplishment_type": {
+      "name": "accomplishment_type",
+      "schema": "public",
+      "values": [
+        "collection_log",
+        "total_level",
+        "ehb",
+        "ehp",
+        "maxed",
+        "elite_diary",
+        "diary_cape",
+        "combat_achievement",
+        "inferno",
+        "colosseum",
+        "blood_torva",
+        "radiant_oathplate",
+        "toa_cursed_phalanx"
+      ]
+    },
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "main",
+        "ironman",
+        "hardcore_ironman",
+        "ultimate_ironman",
+        "group_ironman",
+        "hardcore_group_ironman",
+        "unranked_group_ironman"
+      ]
+    },
+    "public.rank_submission_status": {
+      "name": "rank_submission_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.staff_role": {
+      "name": "staff_role",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "admin",
+        "deputy_owner",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787384998813,
       "tag": "0022_serious_speed",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1787409733648,
+      "tag": "0023_plain_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/derived-item-operations.ts
+++ b/apps/web/lib/db/derived-item-operations.ts
@@ -1,0 +1,119 @@
+import { eq, inArray, sql } from 'drizzle-orm';
+import { db } from './index';
+import { playerDerivedItems } from './schema';
+
+/**
+ * Records what a source last said about the notable items nothing logs.
+ *
+ * **Only ever call this when the deriving source actually answered.** Writing
+ * a screenful of `false` after a failed WikiSync read is precisely the bug
+ * this table exists to prevent: it would turn "we could not ask" into "they do
+ * not have it", and then the floor underneath the next sync would be a lie
+ * rather than a missing row.
+ *
+ * Upserts rather than replacing the set. An item absent from `answers` keeps
+ * whatever was last known about it, which matters when the item list gains an
+ * entry that older rows have never been asked about.
+ */
+export async function syncDerivedItems(
+  playerName: string,
+  answers: Record<string, boolean>,
+): Promise<number> {
+  const rows = Object.entries(answers).map(([itemName, isAcquired]) => ({
+    playerName,
+    itemName,
+    isAcquired,
+  }));
+
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  await db
+    .insert(playerDerivedItems)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: [playerDerivedItems.playerName, playerDerivedItems.itemName],
+      set: {
+        isAcquired: sql`excluded.is_acquired`,
+        updatedAt: new Date(),
+      },
+    });
+
+  return rows.length;
+}
+
+/**
+ * What was last known about one player's unlogged items.
+ *
+ * A missing key means the source has never been read for that item — not that
+ * the player lacks it. Callers must treat absence and `false` differently.
+ */
+export async function getDerivedItems(
+  playerName: string,
+): Promise<Record<string, boolean>> {
+  try {
+    const rows = await db
+      .select({
+        itemName: playerDerivedItems.itemName,
+        isAcquired: playerDerivedItems.isAcquired,
+      })
+      .from(playerDerivedItems)
+      .where(eq(playerDerivedItems.playerName, playerName));
+
+    return rows.reduce<Record<string, boolean>>(
+      (acc, { itemName, isAcquired }) => ({ ...acc, [itemName]: isAcquired }),
+      {},
+    );
+  } catch (error) {
+    // An empty map is "we know nothing", which is a value every caller already
+    // handles — it is the state every player is in before their first sync.
+    //
+    // Swallowed rather than thrown because this read sits on the calculator's
+    // load path: between merging this and running the migration the table does
+    // not exist, and a safety net that can take down the page it protects is
+    // worse than no net. Degrades to the behaviour that shipped before it.
+    console.error('Failed to read derived items, continuing without:', error);
+
+    return {};
+  }
+}
+
+/**
+ * The same, for several players at once — the profile comparison scores two
+ * members side by side and should not issue a query per member to do it.
+ */
+export async function getDerivedItemsForPlayers(
+  playerNames: string[],
+): Promise<Record<string, Record<string, boolean>>> {
+  if (playerNames.length === 0) {
+    return {};
+  }
+
+  const rows = await db
+    .select({
+      playerName: playerDerivedItems.playerName,
+      itemName: playerDerivedItems.itemName,
+      isAcquired: playerDerivedItems.isAcquired,
+    })
+    .from(playerDerivedItems)
+    .where(inArray(playerDerivedItems.playerName, playerNames));
+
+  return rows.reduce<Record<string, Record<string, boolean>>>(
+    (acc, { playerName, itemName, isAcquired }) => ({
+      ...acc,
+      [playerName]: { ...acc[playerName], [itemName]: isAcquired },
+    }),
+    {},
+  );
+}
+
+/**
+ * Deletes a player's rows. Called from `deletePlayer` alongside the other
+ * per-player tables, and from the rename path so the answers follow the name.
+ */
+export async function deleteDerivedItems(playerName: string): Promise<void> {
+  await db
+    .delete(playerDerivedItems)
+    .where(eq(playerDerivedItems.playerName, playerName));
+}

--- a/apps/web/lib/db/player-operations.ts
+++ b/apps/web/lib/db/player-operations.ts
@@ -7,6 +7,7 @@ import {
   playerRankUps,
   playerAccomplishments,
   playerItemOverrides,
+  playerDerivedItems,
   type Player,
   type NewPlayer,
   type PlayerAcquiredItem,
@@ -144,6 +145,9 @@ export async function deletePlayer(
     await tx
       .delete(playerItemOverrides)
       .where(eq(playerItemOverrides.playerName, playerName));
+    await tx
+      .delete(playerDerivedItems)
+      .where(eq(playerDerivedItems.playerName, playerName));
 
     // Delete the player record
     await tx.delete(players).where(eq(players.playerName, playerName));
@@ -960,6 +964,9 @@ export async function resetPlayerClaims(
       })
       .where(eq(players.playerName, playerName));
 
+    // `player_derived_items` is deliberately left alone. This clears the
+    // player's *claims*, and those rows are not a claim — they are what a
+    // source last reported, which a re-sync would arrive at again anyway.
     await tx
       .delete(playerItemOverrides)
       .where(eq(playerItemOverrides.playerName, playerName));

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -321,6 +321,49 @@ export const playerItemOverridesRelations = relations(
 );
 
 /**
+ * The home for the notable items no collection log records.
+ *
+ * Every other notable item is a collection log slot, so `player_acquired_items`
+ * already holds a durable copy of it. Six are not: the four quest items
+ * (Barrows gloves, Book of the dead, Quest cape, Mage Arena 2 cape), the one
+ * combat-achievement item (6 Jads) and Music cape. Those are settled purely by
+ * a live WikiSync read, and until this table they were stored **nowhere** —
+ * recomputed from scratch on every sync and forgotten in between.
+ *
+ * That made them the one part of the calculator with no floor under it. The
+ * scalar equivalents (`has_blood_torva` and friends) are protected by
+ * `currentDbValues` in `fetchPlayerDetails`, on the principle that an
+ * unreachable source says *nothing*, which is not the same as saying no. These
+ * six could not have the same protection because there was no previous answer
+ * to fall back to, so a WikiSync outage silently subtracted up to 480 points
+ * from a member's stored total and left no record that they had ever had it.
+ *
+ * **`is_acquired` is a boolean and the row's absence is a third state.** No row
+ * means the source has never been read for this item; `false` means it was read
+ * and said no. Collapsing those two is exactly the bug this table exists to
+ * fix, so never treat a missing row as a negative.
+ */
+export const playerDerivedItems = pgTable(
+  'player_derived_items',
+  {
+    playerName: varchar('player_name', { length: 12 }).notNull(),
+    /** The form's own key for the item — `stripEntityName(item.name)`. */
+    itemName: text('item_name').notNull(),
+    /** What the source last said. See the note above on the missing row. */
+    isAcquired: boolean('is_acquired').notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    playerDerivedItemPk: primaryKey({
+      columns: [table.playerName, table.itemName],
+    }),
+  }),
+);
+
+export type PlayerDerivedItem = typeof playerDerivedItems.$inferSelect;
+export type NewPlayerDerivedItem = typeof playerDerivedItems.$inferInsert;
+
+/**
  * Notable things a member has done, as a feed alongside rank ups and clogs.
  *
  * Detection is *stateless*: `detectAccomplishments` reports everything a player


### PR DESCRIPTION
## The gap

Every notable item bar six is a collection log slot, so `player_acquired_items` already keeps a durable copy that can be re-read when a source goes quiet. Six are not:

| Item | Points | Settled by |
|---|---|---|
| 6 Jads | 250 | combat achievements |
| Quest cape | 100 | quests |
| Music cape | 100 | music tracks |
| Barrows gloves | 10 | quests |
| Book of the dead | 10 | quests |
| Mage Arena 2 cape | 10 | quests |
| **Total** | **480** | |

All six come purely from a live WikiSync read, and until now they were stored **nowhere** — recomputed on every sync and forgotten in between.

## Why it matters

That made them the one part of the calculator with no floor under it. `fetchPlayerDetails` already protects the scalar equivalents via `currentDbValues`, on the stated principle that *an unreachable source says nothing, which is not the same as saying no*. These six could not have that protection, because there was no previous answer to fall back to.

So when WikiSync is unreachable:

1. `quests` / `combatAchievements` / `musicTracks` are all null → `isItemAcquired` returns false for all six.
2. An override only exists where player and source *disagreed*, so a member whose Quest cape WikiSync normally reports correctly has no override and **no floor**.
3. `processPlayerData` → `calculatePlayerPoints` on the degraded map → `players.points` written up to 480 lower.
4. `syncItemOverrides({derived: [], submitted: []})` → "no/no → nothing to say" → nothing records they ever had it.

## The fix

`player_derived_items` (migration `0023`) is that record.

**`is_acquired` is a boolean and a missing row is a third state.** No row means the source has never been read for this item; `false` means it was read and said no. Collapsing those two is the bug, so nothing may treat absence as a negative.

- **`getSourceDerivedItemNames`** derives the set from the item list (`!isCollectionLogItem`) rather than naming it, so a new `questItem` or `manualItem` is picked up without anyone remembering a constant. Its spec asserts the current six, so adding one fails loudly as a reminder that it needs a home too.
- **`resolveDerivedItemWrite`** owns the decision *not* to write after a failed read, returning `null`. That guard is a tested function rather than an `if` at the call site, because an `if` is one careless edit from deletion and the damage would be silent — the member simply scores 480 less and nothing records otherwise.
- **The read fails soft.** `getDerivedItems` sits on the calculator's load path; between merging this and running the migration the table does not exist, and a safety net that can take down the page it protects is worse than no net. It degrades to the behaviour that shipped before it.
- Rows **follow a rename** and go with a **deleted player**. `resetPlayerClaims` deliberately leaves them — they are what a source reported, not a claim.

## ⚠️ Deploy order

**`yarn db:migrate` has not been run.** There is no automatic migration runner in this repo, and applying DDL to the production Neon database is not something I'd do unasked. The read fails soft so merging before migrating degrades rather than breaks, but the table needs creating before any of this does anything.

## Tested

- `get-source-derived-item-names.spec.ts` (3) and `resolve-derived-item-write.spec.ts` (5) — hermetic, green. The write spec pins all four corners: source answered / didn't, reporting items / nothing — including that an *answering* source reporting nothing is a real negative and must be stored, or an item a member lost would stick forever.
- `tsc`, `eslint` and `yarn build` clean.

## Not verified

- **The outage path itself is not exercised end to end.** `fetch-player-details.spec.ts` is 1,124 lines entirely commented out — stale from the Redis era — so there is no harness to drive a WikiSync failure through `fetchPlayerDetails`. The bug above is read from the code, and the fix is covered only at the level of the two extracted rules. Reviving that spec file is its own job.
- Nothing has been run against a real database; the migration is generated but unapplied.
- Backfill: existing players get their rows on next sync. Until then they have no floor, exactly as today.

<!-- member-summary:start -->
Behind-the-scenes work so a few hard-earned unlocks — your quest cape, music cape and Jad challenges among them — are remembered properly rather than re-checked from scratch each time. If one of the sites we read from is briefly unavailable, your points no longer dip until it comes back.
<!-- member-summary:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)