### PR TITLE
Give the admin page a Discord ban pane

### DIFF
--- a/apps/web/app/admin/actions/ban-discord-member-action.ts
+++ b/apps/web/app/admin/actions/ban-discord-member-action.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { z } from 'zod';
+import { revalidatePath } from 'next/cache';
+import { authActionClient } from '@/app/safe-action';
+import { ActionError } from '@/app/action-error';
+import { banGuildUser } from '../utils/discord-bans';
+import { authorizeDiscordBan } from '../utils/authorize-discord-ban';
+import {
+  buildBanAuditReason,
+  DISCORD_SNOWFLAKE_PATTERN,
+} from '../utils/discord-user-identity';
+
+const BanDiscordMemberSchema = z.object({
+  discordUserId: z
+    .string()
+    .trim()
+    .regex(DISCORD_SNOWFLAKE_PATTERN, 'That is not a Discord user id'),
+  /** Optional, but it is the only record of why — the UI asks for it. */
+  reason: z.string().trim().max(300).optional(),
+});
+
+/**
+ * Bans an account from the clan Discord.
+ *
+ * This changes nothing here: the member keeps their rank, their points and
+ * their calculator. It removes them from the server and stops them rejoining,
+ * which is a Discord concern and stays one.
+ */
+export const banDiscordMemberAction = authActionClient
+  .metadata({ actionName: 'ban-discord-member' })
+  .schema(BanDiscordMemberSchema)
+  .action(
+    async ({ parsedInput: { discordUserId, reason }, ctx: { userId } }) => {
+      const { actorName } = await authorizeDiscordBan(userId, discordUserId);
+
+      const result = await banGuildUser(
+        discordUserId,
+        buildBanAuditReason(reason, actorName),
+      );
+
+      if (result.status === 'unknown-user') {
+        throw new ActionError('Discord does not know that account.');
+      }
+
+      if (result.status === 'missing-permission') {
+        throw new ActionError(
+          'The bot cannot ban that account. It needs the Ban Members permission, and its role must sit above theirs.',
+        );
+      }
+
+      if (result.status !== 'done') {
+        throw new ActionError('Discord could not be reached. Try again shortly.');
+      }
+
+      revalidatePath('/admin');
+
+      return { discordUserId };
+    },
+  );

--- a/apps/web/app/admin/actions/search-discord-members-action.ts
+++ b/apps/web/app/admin/actions/search-discord-members-action.ts
@@ -1,0 +1,93 @@
+'use server';
+
+import { z } from 'zod';
+import { DiscordAPIError } from '@discordjs/rest';
+import { RESTJSONErrorCodes } from 'discord-api-types/v10';
+import { authActionClient } from '@/app/safe-action';
+import { ActionError } from '@/app/action-error';
+import {
+  getClanIdentitiesForDiscordUsers,
+  getStaffIdentityForDiscordUser,
+} from '@/lib/db/staff-operations';
+import {
+  canAccessAdminDashboard,
+  canManageDiscordBan,
+} from '@/app/utils/staff-permissions';
+import { searchGuildUsers } from '../utils/discord-bans';
+
+const SearchDiscordMembersSchema = z.object({
+  query: z.string().trim().min(2).max(64),
+});
+
+export interface DiscordMemberSearchResult {
+  id: string;
+  displayName: string;
+  handle: string;
+  isInServer: boolean;
+  playerNames: string[];
+  canManage: boolean;
+}
+
+/**
+ * Finds accounts to ban, by Discord name or by pasted user id.
+ *
+ * Read-only, but gated all the same — the guild's member list is not something
+ * a signed-in member gets to enumerate by reaching for this action directly.
+ * Every result carries whether the caller may actually ban it, so the pane can
+ * say why a button is missing instead of failing on click.
+ */
+export const searchDiscordMembersAction = authActionClient
+  .metadata({ actionName: 'search-discord-members' })
+  .schema(SearchDiscordMembersSchema)
+  .action(async ({ parsedInput: { query }, ctx: { userId } }) => {
+    const { role: actorRole } = await getStaffIdentityForDiscordUser(userId);
+
+    if (!canAccessAdminDashboard(actorRole)) {
+      throw new ActionError('You do not have access to the admin dashboard');
+    }
+
+    let found;
+
+    try {
+      found = await searchGuildUsers(query);
+    } catch (error) {
+      // Searching members by name needs the Server Members intent switched on
+      // for the bot, and Discord refuses the call as plain missing access when
+      // it is not. Naming the intent is far more useful than "search failed",
+      // because it is a checkbox in the Discord developer portal.
+      if (
+        error instanceof DiscordAPIError &&
+        (error.code === RESTJSONErrorCodes.MissingAccess ||
+          error.code === RESTJSONErrorCodes.MissingPermissions)
+      ) {
+        throw new ActionError(
+          'The bot cannot search members. Enable its Server Members intent in Discord, or paste a user id instead.',
+        );
+      }
+
+      console.error('Discord member search failed:', error);
+
+      throw new ActionError('Discord could not be reached. Try again shortly.');
+    }
+
+    const identities = await getClanIdentitiesForDiscordUsers(
+      found.map((user) => user.id),
+    );
+
+    return {
+      query,
+      results: found.map<DiscordMemberSearchResult>((user) => {
+        const identity = identities.get(user.id);
+
+        return {
+          ...user,
+          playerNames: identity?.playerNames ?? [],
+          canManage: canManageDiscordBan({
+            actorRole,
+            targetRole: identity?.staffRole ?? null,
+            isSelf: user.id === userId,
+          }),
+        };
+      }),
+    };
+  });

--- a/apps/web/app/admin/actions/unban-discord-member-action.ts
+++ b/apps/web/app/admin/actions/unban-discord-member-action.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import { z } from 'zod';
+import { revalidatePath } from 'next/cache';
+import { authActionClient } from '@/app/safe-action';
+import { ActionError } from '@/app/action-error';
+import { unbanGuildUser } from '../utils/discord-bans';
+import { authorizeDiscordBan } from '../utils/authorize-discord-ban';
+import {
+  buildBanAuditReason,
+  DISCORD_SNOWFLAKE_PATTERN,
+} from '../utils/discord-user-identity';
+
+const UnbanDiscordMemberSchema = z.object({
+  discordUserId: z
+    .string()
+    .trim()
+    .regex(DISCORD_SNOWFLAKE_PATTERN, 'That is not a Discord user id'),
+});
+
+/**
+ * Lifts a ban, letting the account back into the server if it asks.
+ *
+ * Held to the same outranking rule as placing one. Lifting a ban is not the
+ * harmless direction — a moderator quietly readmitting someone an owner
+ * removed is exactly what the ladder is there to prevent.
+ */
+export const unbanDiscordMemberAction = authActionClient
+  .metadata({ actionName: 'unban-discord-member' })
+  .schema(UnbanDiscordMemberSchema)
+  .action(async ({ parsedInput: { discordUserId }, ctx: { userId } }) => {
+    const { actorName } = await authorizeDiscordBan(userId, discordUserId);
+
+    const result = await unbanGuildUser(
+      discordUserId,
+      buildBanAuditReason('Ban lifted', actorName),
+    );
+
+    // The ban list this was clicked from is a snapshot. If it has since been
+    // lifted elsewhere the outcome is the one that was wanted, so say so and
+    // let the refresh below correct the page.
+    if (result.status === 'not-banned' || result.status === 'unknown-user') {
+      revalidatePath('/admin');
+
+      return { discordUserId, alreadyLifted: true };
+    }
+
+    if (result.status === 'missing-permission') {
+      throw new ActionError(
+        'The bot cannot lift that ban. It needs the Ban Members permission in Discord.',
+      );
+    }
+
+    if (result.status !== 'done') {
+      throw new ActionError('Discord could not be reached. Try again shortly.');
+    }
+
+    revalidatePath('/admin');
+
+    return { discordUserId, alreadyLifted: false };
+  });

--- a/apps/web/app/admin/admin-panes.tsx
+++ b/apps/web/app/admin/admin-panes.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { LockClosedIcon } from '@radix-ui/react-icons';
+import { SectionHeader } from '@/app/components/section-header';
+import { StaffBadge } from '@/app/components/staff-badge';
+import { getRankName } from '@/app/rank-calculator/utils/get-rank-name';
+import { staffRoleRanks, type StaffRole } from '@/app/schemas/staff';
+import { grantableStaffRoles } from '@/app/utils/staff-permissions';
+import type {
+  StaffDirectoryEntry,
+  StaffRoleChangeEntry,
+} from '@/lib/db/staff-operations';
+import type { DiscordBanEntry } from '@/app/data-sources/fetch-discord-bans';
+import { StaffRoles } from './staff-roles';
+import { DiscordBans } from './discord-bans';
+import styles from './admin.module.css';
+
+type AdminPane = 'staff' | 'bans';
+
+const panes = [
+  { id: 'staff', label: 'Staff ranks' },
+  { id: 'bans', label: 'Discord bans' },
+] as const satisfies readonly { id: AdminPane; label: string }[];
+
+interface AdminPanesProps {
+  viewerRole: StaffRole;
+  viewerPlayerName: string | null;
+  members: StaffDirectoryEntry[];
+  history: StaffRoleChangeEntry[];
+  bans: DiscordBanEntry[] | null;
+  bansError: string | null;
+}
+
+/**
+ * The admin page's sub-menu.
+ *
+ * Two unrelated jobs live here — who is staff, and who is banned from the
+ * Discord — and stacking every panel from both on one column made a page you
+ * had to scroll past one job to reach the other. This swaps which set is
+ * mounted instead.
+ *
+ * Deliberately not routes. Both sets of data are already fetched and handed
+ * down by the server component, so a route per pane would buy a URL at the
+ * cost of a round trip on every switch. If a pane ever needs to be linked to
+ * or bookmarked, that is the point to promote it to `/admin/bans` — until
+ * then, this is the whole mechanism.
+ */
+export function AdminPanes({
+  viewerRole,
+  viewerPlayerName,
+  members,
+  history,
+  bans,
+  bansError,
+}: AdminPanesProps) {
+  const [active, setActive] = useState<AdminPane>('staff');
+  const tabRefs = useRef<Record<AdminPane, HTMLButtonElement | null>>({
+    staff: null,
+    bans: null,
+  });
+
+  const grantable = useMemo(
+    () => grantableStaffRoles(viewerRole),
+    [viewerRole],
+  );
+
+  const subtitle =
+    active === 'staff'
+      ? `Signed in as ${viewerPlayerName ?? 'staff'}. You can assign any role below your own — ${
+          grantable.length
+            ? grantable
+                .map((role) => getRankName(staffRoleRanks[role]))
+                .join(' and ')
+            : 'which, as an administrator, is none'
+        }.`
+      : 'Bans are placed and lifted in the clan Discord. You can act on anyone whose role is below your own.';
+
+  /**
+   * A tablist is expected to move between its tabs with the arrow keys, so Tab
+   * lands on the strip once rather than on every tab in it.
+   */
+  function handleTabKeyDown(event: React.KeyboardEvent) {
+    const offset =
+      event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+
+    if (offset === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const index = panes.findIndex((pane) => pane.id === active);
+    const next = panes[(index + offset + panes.length) % panes.length];
+
+    setActive(next.id);
+    tabRefs.current[next.id]?.focus();
+  }
+
+  return (
+    <>
+      <SectionHeader
+        title="Clan administration"
+        subtitle={subtitle}
+        icon={<LockClosedIcon />}
+        actions={<StaffBadge role={viewerRole} />}
+      />
+
+      <div
+        className={styles.paneTabs}
+        role="tablist"
+        aria-label="Administration sections"
+        onKeyDown={handleTabKeyDown}
+      >
+        {panes.map((pane) => (
+          <button
+            key={pane.id}
+            ref={(element) => {
+              tabRefs.current[pane.id] = element;
+            }}
+            type="button"
+            role="tab"
+            id={`admin-tab-${pane.id}`}
+            aria-selected={active === pane.id}
+            aria-controls={`admin-pane-${pane.id}`}
+            tabIndex={active === pane.id ? 0 : -1}
+            className={styles.paneTab}
+            onClick={() => setActive(pane.id)}
+          >
+            {pane.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        className={styles.pane}
+        role="tabpanel"
+        id={`admin-pane-${active}`}
+        aria-labelledby={`admin-tab-${active}`}
+      >
+        {active === 'staff' ? (
+          <StaffRoles
+            viewerRole={viewerRole}
+            members={members}
+            history={history}
+          />
+        ) : (
+          <DiscordBans bans={bans} error={bansError} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/admin/admin.module.css
+++ b/apps/web/app/admin/admin.module.css
@@ -22,6 +22,56 @@
   gap: 1.5rem;
 }
 
+/* ---------- Pane sub-menu ---------- */
+
+/*
+ * A hairline segmented control, not a nav bar — the panes are two jobs on one
+ * page, and the strip should read as smaller than the page heading above it.
+ */
+.paneTabs {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid rgb(var(--ig-text-muted) / 0.12);
+  border-radius: 10px;
+  background: rgb(var(--ig-surface) / 0.5);
+  align-self: flex-start;
+}
+
+.paneTab {
+  padding: 0.4rem 0.875rem;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgb(var(--ig-text-muted));
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.paneTab:hover[aria-selected='false'] {
+  color: rgb(var(--ig-text));
+}
+
+.paneTab[aria-selected='true'] {
+  background: rgb(var(--ig-secondary) / 0.14);
+  color: rgb(var(--ig-secondary));
+}
+
+.paneTab:focus-visible {
+  outline: 2px solid rgb(var(--ig-secondary) / 0.6);
+  outline-offset: 1px;
+}
+
+/* The mounted pane's own panels keep the column's usual rhythm. */
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 /* ---------- Panels ---------- */
 
 .panel {

--- a/apps/web/app/admin/admin.module.css
+++ b/apps/web/app/admin/admin.module.css
@@ -238,11 +238,116 @@
   background: rgb(var(--ig-secondary) / 0.88);
 }
 
+/*
+ * The one destructive control on the page. Green is the accent everywhere
+ * else, so a ban gets the danger token instead — hairline, not a solid fill,
+ * because it sits in a table row and should not read as the primary action.
+ */
+.dangerButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid rgb(var(--ig-danger) / 0.45);
+  background: transparent;
+  color: rgb(var(--ig-danger));
+}
+
+.dangerButton:hover:not(:disabled) {
+  background: rgb(var(--ig-danger) / 0.12);
+  border-color: rgb(var(--ig-danger) / 0.7);
+}
+
 .manageButton:disabled,
 .primaryButton:disabled,
-.ghostButton:disabled {
+.ghostButton:disabled,
+.dangerButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ---------- Discord bans ---------- */
+
+.discordIdentity {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.discordHandle {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  color: rgb(var(--ig-text-muted));
+}
+
+.discordClanNames {
+  font-size: 0.75rem;
+  color: rgb(var(--ig-text-muted));
+}
+
+.reasonCell {
+  color: rgb(var(--ig-text-muted));
+  max-width: 22rem;
+}
+
+.errorNote {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 1.25rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: rgb(var(--ig-danger));
+}
+
+.reasonField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 1rem;
+}
+
+.reasonLabel {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(var(--ig-text-muted));
+}
+
+.reasonField textarea {
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid rgb(var(--ig-text-muted) / 0.16);
+  border-radius: 8px;
+  background: rgb(var(--ig-bg) / 0.5);
+  font: inherit;
+  font-size: 0.875rem;
+  color: rgb(var(--ig-text));
+  resize: vertical;
+}
+
+.reasonField textarea:focus {
+  outline: none;
+  border-color: rgb(var(--ig-secondary) / 0.6);
+}
+
+.reasonField textarea::placeholder {
+  color: rgb(var(--ig-text-muted) / 0.75);
+}
+
+.reasonHint {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: rgb(var(--ig-text-muted));
 }
 
 /* ---------- History ---------- */

--- a/apps/web/app/admin/discord-bans.tsx
+++ b/apps/web/app/admin/discord-bans.tsx
@@ -1,0 +1,373 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAction } from 'next-safe-action/hooks';
+import { toast } from 'react-toastify';
+import { debounce } from 'lodash';
+import { Dialog, Spinner } from '@radix-ui/themes';
+import {
+  CrossCircledIcon,
+  ExclamationTriangleIcon,
+  MagnifyingGlassIcon,
+} from '@radix-ui/react-icons';
+import { PlayerNameButton } from '@/app/components/player-name-button';
+import type { DiscordBanEntry } from '@/app/data-sources/fetch-discord-bans';
+import { banDiscordMemberAction } from './actions/ban-discord-member-action';
+import { unbanDiscordMemberAction } from './actions/unban-discord-member-action';
+import {
+  searchDiscordMembersAction,
+  type DiscordMemberSearchResult,
+} from './actions/search-discord-members-action';
+import styles from './admin.module.css';
+
+interface DiscordBansProps {
+  bans: DiscordBanEntry[] | null;
+  /** Why the ban list could not be read, if it could not. */
+  error: string | null;
+}
+
+/** A ban the moderator has asked for but not yet confirmed. */
+interface PendingBan {
+  user: DiscordMemberSearchResult;
+}
+
+/** Anything shown in either table, so one row renderer serves both. */
+interface DiscordRow {
+  id: string;
+  displayName: string;
+  handle: string;
+  playerNames: string[];
+}
+
+/**
+ * Discord ban administration.
+ *
+ * Mirrors the staff pane deliberately: the same outranking rule decides who
+ * may act, the same "Outranks you" affordance explains a missing button, and
+ * every control is enforced again server-side. Bans themselves live in
+ * Discord — there is no table here — so the reason recorded against each one
+ * is both the audit trail and what this list shows.
+ */
+export function DiscordBans({ bans, error }: DiscordBansProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<DiscordMemberSearchResult[]>([]);
+  const [pending, setPending] = useState<PendingBan | null>(null);
+  const [reason, setReason] = useState('');
+  const [liftingId, setLiftingId] = useState<string | null>(null);
+
+  // A reply for an earlier, shorter query can land after the finished one.
+  // Only the newest may answer — same guard as the signup name probe.
+  const latestQuery = useRef('');
+
+  const { execute: search, isExecuting: isSearching } = useAction(
+    searchDiscordMembersAction,
+    {
+      onSuccess({ data }) {
+        if (!data || data.query !== latestQuery.current) {
+          return;
+        }
+
+        setResults(data.results);
+      },
+      onError({ error: actionError }) {
+        toast.error(actionError.serverError ?? 'Could not search Discord.');
+        setResults([]);
+      },
+    },
+  );
+
+  // `debounce` has to outlive a render to debounce anything — built inline it
+  // produces a fresh timer per keystroke and every keystroke hits Discord.
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((input: string) => {
+        if (input.trim().length < 2) {
+          setResults([]);
+
+          return;
+        }
+
+        search({ query: input.trim() });
+      }, 400),
+    [search],
+  );
+
+  const { execute: ban, isExecuting: isBanning } = useAction(
+    banDiscordMemberAction,
+    {
+      onSuccess() {
+        toast.success(
+          `${pending?.user.displayName ?? 'That account'} is banned from the Discord.`,
+        );
+        setPending(null);
+        setReason('');
+        setQuery('');
+        setResults([]);
+        latestQuery.current = '';
+        router.refresh();
+      },
+      onError({ error: actionError }) {
+        toast.error(actionError.serverError ?? 'Could not place that ban.');
+      },
+    },
+  );
+
+  const { execute: unban } = useAction(unbanDiscordMemberAction, {
+    onSuccess({ data }) {
+      toast.success(
+        data?.alreadyLifted
+          ? 'That ban had already been lifted.'
+          : 'Ban lifted. They can rejoin the server.',
+      );
+      setLiftingId(null);
+      router.refresh();
+    },
+    onError({ error: actionError }) {
+      toast.error(actionError.serverError ?? 'Could not lift that ban.');
+      setLiftingId(null);
+    },
+  });
+
+  const bannedIds = useMemo(
+    () => new Set((bans ?? []).map((entry) => entry.id)),
+    [bans],
+  );
+
+  function renderIdentity(row: DiscordRow) {
+    return (
+      <div className={styles.discordIdentity}>
+        <span className={styles.name}>{row.displayName}</span>
+        <span className={styles.discordHandle}>{row.handle}</span>
+        {row.playerNames.length > 0 && (
+          <span className={styles.discordClanNames}>
+            {row.playerNames.map((playerName, index) => (
+              <span key={playerName}>
+                {index > 0 && ', '}
+                <PlayerNameButton name={playerName} className={styles.name} />
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <section className={styles.panel} aria-labelledby="bans-heading">
+        <div className={styles.panelHead}>
+          <h3 className={styles.panelTitle} id="bans-heading">
+            Discord bans
+          </h3>
+          <span className={styles.panelMeta}>
+            {error
+              ? 'Unavailable'
+              : `${bans?.length ?? 0} ${bans?.length === 1 ? 'ban' : 'bans'}`}
+          </span>
+        </div>
+        {error ? (
+          <p className={styles.errorNote}>
+            <ExclamationTriangleIcon />
+            Discord’s ban list could not be read. This is usually the bot
+            missing the Ban Members permission in the server.
+          </p>
+        ) : !bans || bans.length === 0 ? (
+          <p className={styles.empty}>Nobody is banned from the Discord.</p>
+        ) : (
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.thLeft}>Account</th>
+                  <th className={styles.thLeft}>Reason</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {bans.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{renderIdentity(entry)}</td>
+                    <td className={styles.reasonCell}>
+                      {entry.reason?.trim()
+                        ? entry.reason
+                        : 'No reason recorded'}
+                    </td>
+                    <td className={styles.actionCell}>
+                      {entry.canManage ? (
+                        <button
+                          type="button"
+                          className={styles.manageButton}
+                          aria-label={`Lift the ban on ${entry.displayName}`}
+                          disabled={liftingId !== null}
+                          onClick={() => {
+                            setLiftingId(entry.id);
+                            unban({ discordUserId: entry.id });
+                          }}
+                        >
+                          {liftingId === entry.id && <Spinner size="1" />}
+                          Lift ban
+                        </button>
+                      ) : (
+                        <span className={styles.noAction}>Outranks you</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.panel} aria-labelledby="ban-search-heading">
+        <div className={styles.panelHead}>
+          <h3 className={styles.panelTitle} id="ban-search-heading">
+            Ban an account
+          </h3>
+          <label className={styles.search}>
+            {isSearching ? <Spinner size="1" /> : <MagnifyingGlassIcon />}
+            <input
+              type="search"
+              value={query}
+              placeholder="Discord name or user id"
+              aria-label="Search Discord members"
+              onChange={(event) => {
+                const input = event.target.value;
+
+                setQuery(input);
+                latestQuery.current = input.trim();
+                debouncedSearch(input);
+              }}
+            />
+          </label>
+        </div>
+        {query.trim().length < 2 ? (
+          <p className={styles.empty}>
+            Search the server by Discord name, or paste a user id to ban someone
+            who has already left.
+          </p>
+        ) : results.length === 0 ? (
+          <p className={styles.empty}>
+            {isSearching
+              ? 'Searching Discord…'
+              : `Nobody in the server matches “${query.trim()}”.`}
+          </p>
+        ) : (
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.thLeft}>Account</th>
+                  <th className={styles.thLeft}>Status</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((user) => {
+                  const alreadyBanned = bannedIds.has(user.id);
+
+                  return (
+                    <tr key={user.id}>
+                      <td>{renderIdentity(user)}</td>
+                      <td className={styles.roleCell}>
+                        {alreadyBanned
+                          ? 'Already banned'
+                          : user.isInServer
+                            ? 'In the server'
+                            : 'Not in the server'}
+                      </td>
+                      <td className={styles.actionCell}>
+                        {alreadyBanned ? (
+                          <span className={styles.noAction}>Banned</span>
+                        ) : user.canManage ? (
+                          <button
+                            type="button"
+                            className={styles.dangerButton}
+                            aria-label={`Ban ${user.displayName}`}
+                            onClick={() => {
+                              setReason('');
+                              setPending({ user });
+                            }}
+                          >
+                            <CrossCircledIcon />
+                            Ban
+                          </button>
+                        ) : (
+                          <span className={styles.noAction}>Outranks you</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <Dialog.Root
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open && !isBanning) {
+            setPending(null);
+          }
+        }}
+      >
+        <Dialog.Content className={styles.dialog} maxWidth="440px">
+          <Dialog.Title className={styles.dialogTitle}>Confirm ban</Dialog.Title>
+          <Dialog.Description className={styles.dialogBody}>
+            <strong>{pending?.user.displayName}</strong> ({pending?.user.handle})
+            will be removed from the Discord server and blocked from rejoining.
+            Their clan rank, points and calculator are left alone — this is a
+            Discord ban only. No messages are deleted.
+          </Dialog.Description>
+          <label className={styles.reasonField}>
+            <span className={styles.reasonLabel}>Reason</span>
+            <textarea
+              value={reason}
+              rows={3}
+              maxLength={300}
+              placeholder="Why they are being banned"
+              aria-label="Ban reason"
+              onChange={(event) => setReason(event.target.value)}
+            />
+            <span className={styles.reasonHint}>
+              Recorded against the ban in Discord, alongside your name. This is
+              the only record of why.
+            </span>
+          </label>
+          <div className={styles.dialogActions}>
+            <button
+              type="button"
+              className={styles.ghostButton}
+              disabled={isBanning}
+              onClick={() => setPending(null)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={styles.dangerButton}
+              disabled={isBanning}
+              onClick={() => {
+                if (!pending) {
+                  return;
+                }
+
+                ban({
+                  discordUserId: pending.user.id,
+                  reason: reason.trim() || undefined,
+                });
+              }}
+            >
+              {isBanning && <Spinner size="1" />}
+              Ban account
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -3,7 +3,9 @@ import { auth } from '@/auth';
 import { NavBar } from '@/app/components/nav-bar';
 import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
 import { fetchAdminDashboard } from '@/app/data-sources/fetch-admin-dashboard';
+import { fetchDiscordBans } from '@/app/data-sources/fetch-discord-bans';
 import { StaffRoles } from './staff-roles';
+import { DiscordBans } from './discord-bans';
 import styles from './admin.module.css';
 
 export const metadata = {
@@ -24,7 +26,13 @@ export default async function AdminPage() {
     redirect('/');
   }
 
-  const result = await fetchAdminDashboard();
+  // Both are gated on the same elevated check, so they can go out together;
+  // only the roster decides whether the page renders at all. The ban list
+  // talks to Discord and is allowed to fail on its own — see the data source.
+  const [result, bansResult] = await Promise.all([
+    fetchAdminDashboard(),
+    fetchDiscordBans(),
+  ]);
 
   if (!result.success) {
     redirect('/dashboard');
@@ -42,6 +50,10 @@ export default async function AdminPage() {
           viewerPlayerName={viewerPlayerName}
           members={members}
           history={history}
+        />
+        <DiscordBans
+          bans={bansResult.success ? bansResult.data.bans : null}
+          error={bansResult.success ? null : bansResult.error}
         />
       </main>
     </div>

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -4,8 +4,7 @@ import { NavBar } from '@/app/components/nav-bar';
 import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
 import { fetchAdminDashboard } from '@/app/data-sources/fetch-admin-dashboard';
 import { fetchDiscordBans } from '@/app/data-sources/fetch-discord-bans';
-import { StaffRoles } from './staff-roles';
-import { DiscordBans } from './discord-bans';
+import { AdminPanes } from './admin-panes';
 import styles from './admin.module.css';
 
 export const metadata = {
@@ -45,15 +44,13 @@ export default async function AdminPage() {
     <div className={styles.page}>
       <NavBar currentPage="admin" userCalculators={userCalculators} />
       <main className={styles.main}>
-        <StaffRoles
+        <AdminPanes
           viewerRole={viewerRole}
           viewerPlayerName={viewerPlayerName}
           members={members}
           history={history}
-        />
-        <DiscordBans
           bans={bansResult.success ? bansResult.data.bans : null}
-          error={bansResult.success ? null : bansResult.error}
+          bansError={bansResult.success ? null : bansResult.error}
         />
       </main>
     </div>

--- a/apps/web/app/admin/staff-roles.tsx
+++ b/apps/web/app/admin/staff-roles.tsx
@@ -7,11 +7,9 @@ import { toast } from 'react-toastify';
 import { Dialog, DropdownMenu, Spinner } from '@radix-ui/themes';
 import {
   ChevronDownIcon,
-  LockClosedIcon,
   MagnifyingGlassIcon,
   PersonIcon,
 } from '@radix-ui/react-icons';
-import { SectionHeader } from '@/app/components/section-header';
 import { StaffBadge } from '@/app/components/staff-badge';
 import { AccountTypeBadge } from '@/app/components/account-type-badge';
 import { PlayerNameButton } from '@/app/components/player-name-button';
@@ -34,7 +32,6 @@ import styles from './admin.module.css';
 
 interface StaffRolesProps {
   viewerRole: StaffRole;
-  viewerPlayerName: string | null;
   members: StaffDirectoryEntry[];
   history: StaffRoleChangeEntry[];
 }
@@ -49,15 +46,17 @@ const roleLabel = (role: StaffRole | null) =>
   role ? getRankName(staffRoleRanks[role]) : 'No role';
 
 /**
- * Staff role administration.
+ * Staff role administration — the admin page's default pane.
  *
  * Every control here is also enforced server-side — this decides what is worth
  * offering, not what is allowed. See `app/utils/staff-permissions.ts` for the
  * one rule behind all of it: you may only assign a role below your own.
+ *
+ * The page heading belongs to `AdminPanes`, not here: it names the page rather
+ * than this pane, and stays put while the pane under it swaps.
  */
 export function StaffRoles({
   viewerRole,
-  viewerPlayerName,
   members,
   history,
 }: StaffRolesProps) {
@@ -243,17 +242,6 @@ export function StaffRoles({
 
   return (
     <>
-      <SectionHeader
-        title="Clan administration"
-        subtitle={`Signed in as ${viewerPlayerName ?? 'staff'}. You can assign any role below your own — ${
-          grantable.length
-            ? grantable.map(roleLabel).join(' and ')
-            : 'which, as an administrator, is none'
-        }.`}
-        icon={<LockClosedIcon />}
-        actions={<StaffBadge role={viewerRole} />}
-      />
-
       <section className={styles.panel} aria-labelledby="staff-heading">
         <div className={styles.panelHead}>
           <h3 className={styles.panelTitle} id="staff-heading">

--- a/apps/web/app/admin/utils/authorize-discord-ban.ts
+++ b/apps/web/app/admin/utils/authorize-discord-ban.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+import { ActionError } from '@/app/action-error';
+import { getStaffIdentityForDiscordUser } from '@/lib/db/staff-operations';
+import {
+  canAccessAdminDashboard,
+  canManageDiscordBan,
+} from '@/app/utils/staff-permissions';
+
+/**
+ * The check every ban action runs, against the database rather than against
+ * anything the client said.
+ *
+ * Both halves matter. The actor's own standing is re-read from their Discord
+ * session, and the *target's* standing is read too — the dashboard renders
+ * what it may do, but a member can be promoted between that render and the
+ * click, and an admin banning the owner out of the server is not a mistake
+ * there is any way back from.
+ *
+ * Returns the actor's clan name, which is what the ban's recorded reason
+ * attributes it to.
+ */
+export async function authorizeDiscordBan(
+  actorDiscordUserId: string,
+  targetDiscordUserId: string,
+): Promise<{ actorName: string }> {
+  const { role: actorRole, playerName: actorPlayerName } =
+    await getStaffIdentityForDiscordUser(actorDiscordUserId);
+
+  if (!canAccessAdminDashboard(actorRole)) {
+    throw new ActionError('You do not have access to the admin dashboard');
+  }
+
+  const { role: targetRole } = await getStaffIdentityForDiscordUser(
+    targetDiscordUserId,
+  );
+
+  const allowed = canManageDiscordBan({
+    actorRole,
+    targetRole,
+    isSelf: targetDiscordUserId === actorDiscordUserId,
+  });
+
+  if (!allowed) {
+    throw new ActionError(
+      targetDiscordUserId === actorDiscordUserId
+        ? 'You cannot ban yourself.'
+        : 'You cannot ban this member. They hold a staff role at or above your own.',
+    );
+  }
+
+  // Falls back to the Discord id when the actor tracks no account here, so the
+  // ban is still attributed to someone rather than to the bot.
+  return { actorName: actorPlayerName ?? `Discord user ${actorDiscordUserId}` };
+}

--- a/apps/web/app/admin/utils/discord-bans.ts
+++ b/apps/web/app/admin/utils/discord-bans.ts
@@ -1,0 +1,267 @@
+import 'server-only';
+import * as Sentry from '@sentry/nextjs';
+import { DiscordAPIError } from '@discordjs/rest';
+import {
+  APIBan,
+  APIGuildMember,
+  APIUser,
+  RESTJSONErrorCodes,
+  Routes,
+} from 'discord-api-types/v10';
+import { serverConstants } from '@/config/constants.server';
+import { discordBotClient } from '@/discord';
+import {
+  describeDiscordUser,
+  isDiscordSnowflake,
+  type DiscordUserIdentity,
+} from './discord-user-identity';
+
+/** A ban as Discord holds it, named for display. */
+export interface GuildBan extends DiscordUserIdentity {
+  /** Whatever was recorded when the ban was placed, if anything. */
+  reason: string | null;
+}
+
+/** A candidate the search pane offers up. */
+export interface GuildUserSearchResult extends DiscordUserIdentity {
+  /**
+   * False when the account was found by id but is not in the server. Discord
+   * allows banning them anyway, which is how someone is kept out pre-emptively.
+   */
+  isInServer: boolean;
+}
+
+export type DiscordBanActionResult =
+  | { status: 'done' }
+  | { status: 'not-banned' }
+  | { status: 'missing-permission' }
+  | { status: 'unknown-user' }
+  | { status: 'failed'; error: string };
+
+/** Discord's maximum page size for the ban list. */
+const BAN_PAGE_SIZE = 1000;
+
+/**
+ * A stop on the pagination loop. Ten pages is ten thousand bans — far past
+ * anything a clan server will hold, so hitting it means the cursor is not
+ * advancing, and looping forever against Discord is the worse failure.
+ */
+const MAX_BAN_PAGES = 10;
+
+const SEARCH_RESULT_LIMIT = 10;
+
+function reportDiscordFailure(error: unknown, extra: Record<string, unknown>) {
+  console.error('Discord ban operation failed:', error);
+
+  Sentry.captureException(error, {
+    tags: { area: 'discord-bans' },
+    extra,
+  });
+}
+
+/**
+ * Every account banned from the guild.
+ *
+ * Discord pages this endpoint by user id rather than by offset, so each page
+ * asks for what follows the last id seen. The list comes back sorted by id,
+ * which is not the order anyone banned them in — the panel sorts for display.
+ */
+export async function listGuildBans(): Promise<GuildBan[]> {
+  const { guildId } = serverConstants.discord;
+  const bans: GuildBan[] = [];
+  let after: string | undefined;
+
+  for (let page = 0; page < MAX_BAN_PAGES; page += 1) {
+    const query = new URLSearchParams({ limit: String(BAN_PAGE_SIZE) });
+
+    if (after) {
+      query.set('after', after);
+    }
+
+    // Sequential by necessity: each page is addressed by the last id of the
+    // one before it.
+    const batch = (await discordBotClient.get(Routes.guildBans(guildId), {
+      query,
+    })) as APIBan[];
+
+    bans.push(
+      ...batch.map((ban) => ({
+        ...describeDiscordUser(ban.user),
+        reason: ban.reason,
+      })),
+    );
+
+    if (batch.length < BAN_PAGE_SIZE) {
+      break;
+    }
+
+    after = batch[batch.length - 1]?.user.id;
+
+    if (!after) {
+      break;
+    }
+  }
+
+  return bans;
+}
+
+/**
+ * Looks up one account by id, whether or not it is in the server.
+ *
+ * Tried before the member search because a pasted id is an exact answer, and
+ * because it is the only way to reach someone who has already left — the
+ * member search can only see people who are still here.
+ */
+async function findDiscordUserById(
+  id: string,
+): Promise<GuildUserSearchResult | null> {
+  const { guildId } = serverConstants.discord;
+
+  try {
+    const member = (await discordBotClient.get(
+      Routes.guildMember(guildId, id),
+    )) as APIGuildMember;
+
+    return {
+      ...describeDiscordUser(member.user, member.nick),
+      isInServer: true,
+    };
+  } catch (error) {
+    if (
+      !(error instanceof DiscordAPIError) ||
+      error.code !== RESTJSONErrorCodes.UnknownMember
+    ) {
+      throw error;
+    }
+  }
+
+  try {
+    const user = (await discordBotClient.get(Routes.user(id))) as APIUser;
+
+    return { ...describeDiscordUser(user), isInServer: false };
+  } catch (error) {
+    if (
+      error instanceof DiscordAPIError &&
+      error.code === RESTJSONErrorCodes.UnknownUser
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Finds accounts to ban, by name or by id.
+ *
+ * The name search only covers people currently in the server, which is the
+ * right default — the pane exists to remove someone who is here. Pasting an id
+ * additionally reaches accounts that have already left, so a known bad actor
+ * can be locked out before they rejoin.
+ */
+export async function searchGuildUsers(
+  query: string,
+): Promise<GuildUserSearchResult[]> {
+  const { guildId } = serverConstants.discord;
+  const trimmed = query.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  if (isDiscordSnowflake(trimmed)) {
+    const found = await findDiscordUserById(trimmed);
+
+    return found ? [found] : [];
+  }
+
+  const members = (await discordBotClient.get(
+    Routes.guildMembersSearch(guildId),
+    {
+      query: new URLSearchParams({
+        query: trimmed,
+        limit: String(SEARCH_RESULT_LIMIT),
+      }),
+    },
+  )) as APIGuildMember[];
+
+  return members.map((member) => ({
+    ...describeDiscordUser(member.user, member.nick),
+    isInServer: true,
+  }));
+}
+
+function classifyDiscordError(error: unknown): DiscordBanActionResult {
+  if (error instanceof DiscordAPIError) {
+    // The bot's own role has to carry BAN_MEMBERS and sit above the target's
+    // highest role. Both are server settings, so this is worth naming rather
+    // than reporting as a generic failure.
+    if (error.code === RESTJSONErrorCodes.MissingPermissions) {
+      return { status: 'missing-permission' };
+    }
+
+    if (error.code === RESTJSONErrorCodes.UnknownUser) {
+      return { status: 'unknown-user' };
+    }
+
+    if (error.code === RESTJSONErrorCodes.UnknownBan) {
+      return { status: 'not-banned' };
+    }
+  }
+
+  return { status: 'failed', error: String(error) };
+}
+
+/**
+ * Bans an account from the guild.
+ *
+ * No message deletion is requested. Discord can purge up to a week of the
+ * banned account's messages on the way out, but that is irreversible and
+ * separate from keeping them out, so it is deliberately not offered here.
+ */
+export async function banGuildUser(
+  discordUserId: string,
+  auditReason: string,
+): Promise<DiscordBanActionResult> {
+  const { guildId } = serverConstants.discord;
+
+  try {
+    await discordBotClient.put(Routes.guildBan(guildId, discordUserId), {
+      reason: auditReason,
+    });
+
+    return { status: 'done' };
+  } catch (error) {
+    const result = classifyDiscordError(error);
+
+    if (result.status === 'failed') {
+      reportDiscordFailure(error, { discordUserId, action: 'ban' });
+    }
+
+    return result;
+  }
+}
+
+/** Lifts a ban. The account is not re-invited — it is only allowed back in. */
+export async function unbanGuildUser(
+  discordUserId: string,
+  auditReason: string,
+): Promise<DiscordBanActionResult> {
+  const { guildId } = serverConstants.discord;
+
+  try {
+    await discordBotClient.delete(Routes.guildBan(guildId, discordUserId), {
+      reason: auditReason,
+    });
+
+    return { status: 'done' };
+  } catch (error) {
+    const result = classifyDiscordError(error);
+
+    if (result.status === 'failed') {
+      reportDiscordFailure(error, { discordUserId, action: 'unban' });
+    }
+
+    return result;
+  }
+}

--- a/apps/web/app/admin/utils/discord-user-identity.spec.ts
+++ b/apps/web/app/admin/utils/discord-user-identity.spec.ts
@@ -1,0 +1,84 @@
+import type { APIUser } from 'discord-api-types/v10';
+import {
+  buildBanAuditReason,
+  describeDiscordUser,
+  isDiscordSnowflake,
+} from './discord-user-identity';
+
+const user = (overrides: Partial<APIUser> = {}) =>
+  ({
+    id: '80351110224678912',
+    username: 'nelly',
+    global_name: null,
+    discriminator: '0',
+    avatar: null,
+    ...overrides,
+  }) as APIUser;
+
+describe('describeDiscordUser', () => {
+  it('prefers the server nickname over every other name', () => {
+    expect(
+      describeDiscordUser(user({ global_name: 'Nelly' }), 'Zezima'),
+    ).toMatchObject({ displayName: 'Zezima' });
+  });
+
+  it('falls back to the display name, then the username', () => {
+    expect(describeDiscordUser(user({ global_name: 'Nelly' }))).toMatchObject({
+      displayName: 'Nelly',
+    });
+
+    expect(describeDiscordUser(user())).toMatchObject({ displayName: 'nelly' });
+  });
+
+  it('treats an empty nickname as no nickname', () => {
+    expect(
+      describeDiscordUser(user({ global_name: 'Nelly' }), ''),
+    ).toMatchObject({ displayName: 'Nelly' });
+  });
+
+  it('renders a migrated account as an @handle', () => {
+    expect(describeDiscordUser(user())).toMatchObject({ handle: '@nelly' });
+  });
+
+  it('keeps the discriminator on a legacy account', () => {
+    expect(describeDiscordUser(user({ discriminator: '1337' }))).toMatchObject({
+      handle: 'nelly#1337',
+    });
+  });
+});
+
+describe('isDiscordSnowflake', () => {
+  it.each(['80351110224678912', ' 1301172323742781524 '])(
+    'accepts %s',
+    (value) => {
+      expect(isDiscordSnowflake(value)).toBe(true);
+    },
+  );
+
+  it.each(['', 'nelly', '12345', '803511102246789123456', '8035111022467891a'])(
+    'rejects %s',
+    (value) => {
+      expect(isDiscordSnowflake(value)).toBe(false);
+    },
+  );
+});
+
+describe('buildBanAuditReason', () => {
+  it('attributes the ban to the moderator who placed it', () => {
+    expect(buildBanAuditReason('Advertising', 'Zezima')).toBe(
+      'Advertising (by Zezima via the Grotto admin page)',
+    );
+  });
+
+  it('still records who acted when no reason was given', () => {
+    expect(buildBanAuditReason('   ', 'Zezima')).toBe(
+      'No reason given (by Zezima via the Grotto admin page)',
+    );
+  });
+
+  it('stays inside the audit-log reason limit Discord enforces', () => {
+    const reason = buildBanAuditReason('x'.repeat(600), 'Zezima');
+
+    expect(reason).toHaveLength(512);
+  });
+});

--- a/apps/web/app/admin/utils/discord-user-identity.ts
+++ b/apps/web/app/admin/utils/discord-user-identity.ts
@@ -1,0 +1,81 @@
+import type { APIUser } from 'discord-api-types/v10';
+
+/**
+ * How a Discord account is shown in the ban panes: the name a moderator would
+ * recognise, plus the handle that identifies it unambiguously.
+ */
+export interface DiscordUserIdentity {
+  id: string;
+  /** Server nickname, then display name, then the raw username. */
+  displayName: string;
+  /** The `@handle` — or `name#0001` on a legacy, un-migrated account. */
+  handle: string;
+}
+
+/** Discord's sentinel for an account migrated to the `@handle` system. */
+const LEGACY_DISCRIMINATOR = '0';
+
+/**
+ * A user id as Discord issues them. Snowflakes are 64-bit, so they arrive as
+ * strings of 17–20 digits — anything else was typed by hand and is not one.
+ */
+export const DISCORD_SNOWFLAKE_PATTERN = /^\d{17,20}$/;
+
+export function isDiscordSnowflake(value: string) {
+  return DISCORD_SNOWFLAKE_PATTERN.test(value.trim());
+}
+
+/**
+ * Names a Discord account for display.
+ *
+ * Three fields can carry a name and they are not interchangeable: `nick` is
+ * what this server calls them, `global_name` is what they call themselves, and
+ * `username` is the only one guaranteed to exist. A moderator looking at a ban
+ * list wants the first one they would recognise, so they are tried in that
+ * order.
+ */
+export function describeDiscordUser(
+  user: APIUser,
+  nickname?: string | null,
+): DiscordUserIdentity {
+  const isLegacyAccount =
+    Boolean(user.discriminator) && user.discriminator !== LEGACY_DISCRIMINATOR;
+
+  // A blank nickname has to fall through like a missing one — Discord returns
+  // an empty string for a nickname that was set and then cleared.
+  const displayName =
+    [nickname, user.global_name].find((name) => name?.trim()) ?? user.username;
+
+  return {
+    id: user.id,
+    displayName,
+    handle: isLegacyAccount
+      ? `${user.username}#${user.discriminator}`
+      : `@${user.username}`,
+  };
+}
+
+/** Discord rejects an audit-log reason longer than this. */
+const AUDIT_LOG_REASON_LIMIT = 512;
+
+/**
+ * The reason recorded against the ban, in Discord.
+ *
+ * There is no `discord_bans` table and there does not need to be one: Discord
+ * stores the reason on the ban itself and hands it back with the ban list, so
+ * writing the actor into it makes the list its own audit trail — and puts the
+ * same line in the server's audit log, where the bot would otherwise be the
+ * only actor recorded.
+ */
+export function buildBanAuditReason(
+  reason: string | null | undefined,
+  actorName: string,
+): string {
+  const trimmed = reason?.trim();
+  const attribution = `(by ${actorName} via the Grotto admin page)`;
+  const full = trimmed
+    ? `${trimmed} ${attribution}`
+    : `No reason given ${attribution}`;
+
+  return full.slice(0, AUDIT_LOG_REASON_LIMIT);
+}

--- a/apps/web/app/data-sources/fetch-discord-bans.ts
+++ b/apps/web/app/data-sources/fetch-discord-bans.ts
@@ -1,0 +1,82 @@
+import { auth } from '@/auth';
+import {
+  getClanIdentitiesForDiscordUsers,
+  getStaffIdentityForDiscordUser,
+} from '@/lib/db/staff-operations';
+import {
+  canAccessAdminDashboard,
+  canManageDiscordBan,
+} from '@/app/utils/staff-permissions';
+import { listGuildBans, type GuildBan } from '@/app/admin/utils/discord-bans';
+
+export interface DiscordBanEntry extends GuildBan {
+  /** Clan accounts this Discord user tracks here, if any. */
+  playerNames: string[];
+  /** Whether the signed-in moderator may lift this ban. */
+  canManage: boolean;
+}
+
+export interface DiscordBansData {
+  bans: DiscordBanEntry[];
+}
+
+/**
+ * The guild's ban list, annotated for whoever is signed in.
+ *
+ * Kept out of `fetchAdminDashboard` on purpose: this one talks to Discord, and
+ * the dashboard redirects away when its fetch fails. A Discord outage should
+ * cost the ban pane, not the whole page — so the failure is returned and the
+ * pane renders it.
+ */
+export async function fetchDiscordBans(): Promise<
+  { success: true; data: DiscordBansData } | { success: false; error: string }
+> {
+  try {
+    const session = await auth();
+    const discordUserId = session?.user?.id;
+
+    if (!discordUserId) {
+      return { success: false, error: 'Not signed in' };
+    }
+
+    const { role: viewerRole } =
+      await getStaffIdentityForDiscordUser(discordUserId);
+
+    if (!canAccessAdminDashboard(viewerRole)) {
+      return { success: false, error: 'Not an elevated account' };
+    }
+
+    const bans = await listGuildBans();
+    const identities = await getClanIdentitiesForDiscordUsers(
+      bans.map((ban) => ban.id),
+    );
+
+    return {
+      success: true,
+      data: {
+        bans: bans
+          .map((ban) => {
+            const identity = identities.get(ban.id);
+
+            return {
+              ...ban,
+              playerNames: identity?.playerNames ?? [],
+              canManage: canManageDiscordBan({
+                actorRole: viewerRole,
+                targetRole: identity?.staffRole ?? null,
+                isSelf: ban.id === discordUserId,
+              }),
+            };
+          })
+          // Discord returns these ordered by user id, which is the order the
+          // accounts were created in and means nothing here. Name order is at
+          // least the order a moderator would look them up in.
+          .sort((a, b) => a.displayName.localeCompare(b.displayName)),
+      },
+    };
+  } catch (error) {
+    console.error('Failed to fetch Discord bans:', error);
+
+    return { success: false, error: String(error) };
+  }
+}

--- a/apps/web/app/utils/staff-permissions.spec.ts
+++ b/apps/web/app/utils/staff-permissions.spec.ts
@@ -1,6 +1,7 @@
 import {
   canAccessAdminDashboard,
   canAssignStaffRole,
+  canManageDiscordBan,
   canManageStaffRole,
   grantableStaffRoles,
   outranks,
@@ -201,5 +202,58 @@ describe('canAssignStaffRole', () => {
         nextRole: 'admin',
       }),
     ).toBe(false);
+  });
+});
+
+describe('canManageDiscordBan', () => {
+  /**
+   * The common case: whoever is being banned has no clan account at all, so
+   * no role, so they sit below every moderator.
+   */
+  it('lets an elevated account ban someone with no clan standing', () => {
+    expect(
+      canManageDiscordBan({ actorRole: 'admin', targetRole: null }),
+    ).toBe(true);
+  });
+
+  it('refuses to ban a member who outranks the actor', () => {
+    expect(
+      canManageDiscordBan({ actorRole: 'admin', targetRole: 'owner' }),
+    ).toBe(false);
+  });
+
+  it('refuses to ban a member of equal standing', () => {
+    expect(
+      canManageDiscordBan({
+        actorRole: 'deputy_owner',
+        targetRole: 'deputy_owner',
+      }),
+    ).toBe(false);
+  });
+
+  it('refuses to ban yourself', () => {
+    expect(
+      canManageDiscordBan({
+        actorRole: 'owner',
+        targetRole: 'owner',
+        isSelf: true,
+      }),
+    ).toBe(false);
+  });
+
+  /**
+   * A moderator is not an elevated account, so they never reach the dashboard
+   * — and must not be able to ban by calling the action directly either.
+   */
+  it('turns away a moderator', () => {
+    expect(
+      canManageDiscordBan({ actorRole: 'moderator', targetRole: null }),
+    ).toBe(false);
+  });
+
+  it('turns away a member with no staff role', () => {
+    expect(canManageDiscordBan({ actorRole: null, targetRole: null })).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/app/utils/staff-permissions.ts
+++ b/apps/web/app/utils/staff-permissions.ts
@@ -107,6 +107,23 @@ export function canManageStaffRole({
   return outranks(actorRole, targetRole);
 }
 
+/**
+ * Whether `actor` may ban or lift the ban on this Discord account.
+ *
+ * The same ladder, for the same reason: a Discord ban is the most destructive
+ * thing the dashboard can do, so an admin must not be able to ban the owner
+ * out of the server, and nobody may ban themselves. Someone with no clan
+ * account has a null role and is below everyone — which is the common case,
+ * since most people worth banning were never members.
+ */
+export function canManageDiscordBan({
+  actorRole,
+  targetRole,
+  isSelf = false,
+}: ManageMemberInput) {
+  return canManageStaffRole({ actorRole, targetRole, isSelf });
+}
+
 type AssignStaffRoleInput = ManageMemberInput & {
   /** The role being written, or null to strip the member of their role. */
   nextRole: StaffRole | null;

--- a/apps/web/lib/db/staff-operations.ts
+++ b/apps/web/lib/db/staff-operations.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm';
 import { db } from './index';
 import { players, staffRoleChanges } from './schema';
 import type { StaffRole } from '@/app/schemas/staff';
@@ -57,6 +57,64 @@ export async function getStaffIdentityForDiscordUser(
     },
     { role: null, playerName: null },
   );
+}
+
+export interface ClanIdentity {
+  /** Every account this Discord user tracks here, active or not. */
+  playerNames: string[];
+  /** The highest role held on an **active** account, null if none. */
+  staffRole: StaffRole | null;
+}
+
+/**
+ * Who these Discord accounts are in the clan, in one query.
+ *
+ * Used by the ban panes, where most ids belong to nobody and the rest may
+ * belong to someone who left. Names are collected from every row, including
+ * soft-deleted ones — knowing a banned account used to be a member is exactly
+ * the context a moderator wants — but the staff role is read only from active
+ * rows, because that is what standing means everywhere else in this file.
+ */
+export async function getClanIdentitiesForDiscordUsers(
+  discordUserIds: string[],
+): Promise<Map<string, ClanIdentity>> {
+  const identities = new Map<string, ClanIdentity>();
+
+  if (discordUserIds.length === 0) {
+    return identities;
+  }
+
+  const rows = await db
+    .select({
+      discordUserId: players.discordUserId,
+      playerName: players.playerName,
+      staffRole: players.staffRole,
+      isActive: players.isActive,
+    })
+    .from(players)
+    .where(inArray(players.discordUserId, [...new Set(discordUserIds)]));
+
+  rows.forEach(({ discordUserId, playerName, staffRole, isActive }) => {
+    const existing = identities.get(discordUserId) ?? {
+      playerNames: [],
+      staffRole: null,
+    };
+
+    existing.playerNames.push(playerName);
+
+    if (
+      isActive &&
+      staffRole &&
+      (!existing.staffRole ||
+        staffRoleOrder[staffRole] > staffRoleOrder[existing.staffRole])
+    ) {
+      existing.staffRole = staffRole;
+    }
+
+    identities.set(discordUserId, existing);
+  });
+
+  return identities;
 }
 
 export interface StaffDirectoryEntry {


### PR DESCRIPTION
Adds Discord ban administration to `/admin`, and puts it behind a sub-menu alongside the existing staff-role panels.

## The sub-menu

`/admin` now has two panes — **Staff ranks** (the default) and **Discord bans** — behind a small hairline segmented control under the page heading. `AdminPanes` swaps which set of panels is mounted.

Deliberately **not routes**. Both sets of data are already fetched and handed down by the server component, so a route per pane would buy a URL at the cost of a round trip on every switch. The point to promote a pane to `/admin/bans` is when it needs linking to or bookmarking, not before.

The page heading moved out of `StaffRoles` into the shell — it names the page rather than the pane, and stays put while the pane under it swaps. Its subtitle follows the active pane. The strip is a real tablist, so arrow keys move between panes and Tab lands on it once rather than on every tab in it.

## What's in the bans pane

**Discord bans** — the guild's current ban list, each entry showing the account's display name and handle, the clan name(s) it tracks here if any, and the reason recorded against the ban. Each row has a **Lift ban** action.

**Ban an account** — a debounced search that finds someone to ban, by Discord name or by pasted user id. Banning goes through a confirm dialog with a reason field.

## How it works

**No table, no migration.** Discord stores a reason on the ban itself and returns it with the ban list, so `buildBanAuditReason` writes the acting moderator's clan name into it. The list is its own audit trail, and the server's audit log names a person rather than the bot.

**The same ladder decides who may act.** `canManageDiscordBan` in `app/utils/staff-permissions.ts` delegates to `canManageStaffRole` — elevated accounts only, you must outrank the target, and you can never act on yourself. So an admin cannot ban the owner out of the server. `authorizeDiscordBan` re-reads both the actor's and the target's standing from the database on every action, against the target's role *now* rather than the copy the dashboard rendered.

**The pane can fail without taking the page with it.** `fetchDiscordBans` is deliberately not folded into `fetchAdminDashboard`: that one redirects to `/dashboard` when it fails, and a Discord outage should cost the ban pane, not the whole admin page. The pane renders an error state instead.

**Searching by id reaches accounts that have left.** The member search only sees people currently in the server, which is the right default. A pasted snowflake falls back to `GET /users/{id}`, so a known bad actor can be locked out before they rejoin.

**No message deletion.** Discord can purge up to a week of the banned account's messages on the way out. That is irreversible and separate from keeping them out, so it is not offered.

A ban changes nothing on this side — rank, points and calculator are left alone, and the confirm dialog says so.

## Files

- `app/admin/admin-panes.tsx` — the sub-menu shell, owns which pane is mounted
- `app/utils/staff-permissions.ts` — `canManageDiscordBan` (the permission model stays in one file, per CLAUDE.md)
- `app/admin/utils/discord-user-identity.ts` — pure naming + audit-reason helpers
- `app/admin/utils/discord-bans.ts` — the Discord REST surface (list/paginate, search, ban, unban)
- `app/admin/utils/authorize-discord-ban.ts` — the check all three actions run
- `app/admin/actions/{ban,unban,search}-*.ts` — the server actions
- `app/data-sources/fetch-discord-bans.ts` — the list, annotated for the viewer
- `app/admin/discord-bans.tsx` + `admin.module.css` — the panes (tokens only, no raw colours)
- `lib/db/staff-operations.ts` — `getClanIdentitiesForDiscordUsers`, one query for the whole list

## Testing

- `yarn check-types` — clean. The four `submit-rank-calculator.spec.ts` errors are pre-existing on `main` (verified by stashing).
- `yarn test app/admin app/utils/staff-permissions` — 58 passing. New specs cover the naming rules (nickname → display name → username, blank nickname falling through, legacy `#discriminator` handles), snowflake detection, audit-reason attribution and the 512-char Discord limit; `canManageDiscordBan` is spec'd for outranking, equal standing, self, moderator and no-role.
- `yarn build` — succeeds.
- `npx eslint` on every changed file — clean.

**Not verified:** nothing here has been exercised against the live Discord API, and the sub-menu has not been clicked in a browser. `/admin` is auth-gated and the calls need a real guild, so the ban list, the member search, placing/lifting a ban, and the pane swap were not run end to end.

Two things worth checking on the server before this is useful:

1. **The bot needs the Ban Members permission.** Its `Robots` role currently carries MANAGE_ROLES (that is what the staff-role sync uses); ban is a separate permission. Without it the pane shows its error state and actions return a message naming the missing permission.
2. **Member search by name needs the Server Members intent** enabled for the bot in the Discord developer portal. Without it the search action says so explicitly, and searching by pasted user id still works.

<!-- member-summary:start -->
Clan staff can now see and manage the Discord server's ban list from the admin page — including lifting a ban, and searching for an account to remove.
<!-- member-summary:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)