### PR TITLE
Add a Maggot King Speed Chaser planner under a new Tools menu

### DIFF
--- a/apps/web/app/components/nav-bar.tsx
+++ b/apps/web/app/components/nav-bar.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDownIcon,
   DotsHorizontalIcon,
   PlusIcon,
+  StopwatchIcon,
 } from '@radix-ui/react-icons';
 import { DropdownMenu, Spinner } from '@radix-ui/themes';
 import { useState, useTransition } from 'react';
@@ -28,7 +29,7 @@ import { useViewerStaffRole } from './use-viewer-staff-role';
 import styles from './nav-bar.module.css';
 
 interface NavBarProps {
-  currentPage?: 'dashboard' | 'player' | 'submission' | 'admin';
+  currentPage?: 'dashboard' | 'player' | 'submission' | 'admin' | 'tools';
   playerName?: string;
   /**
    * Renders the calculator's own actions: the "Apply for promotion" button and
@@ -213,6 +214,34 @@ export function NavBar({
                 <Link href="/rank-calculator/players/add">
                   <PlusIcon />
                   New account
+                </Link>
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+
+          {/* Standalone calculators for specific in-game content. They read no
+              player data, so unlike everything else in this bar they work
+              signed out — the menu is here rather than on a /tools index
+              because one click should reach the tool. */}
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <button
+                type="button"
+                className={`${styles.link} ${
+                  currentPage === 'tools' ? styles.linkActive : ''
+                }`}
+              >
+                Tools
+                <ChevronDownIcon />
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Label>Combat achievements</DropdownMenu.Label>
+              <DropdownMenu.Item asChild>
+                <Link href="/tools/maggot-king">
+                  <StopwatchIcon />
+                  Maggot King
+                  <span className={styles.menuMeta}>Speed Chaser</span>
                 </Link>
               </DropdownMenu.Item>
             </DropdownMenu.Content>

--- a/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.spec.tsx
+++ b/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.spec.tsx
@@ -1,0 +1,107 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MaggotKingSpeedChaser } from './maggot-king-speed-chaser';
+
+/**
+ * The stat tiles are queried by their `aria-label`, which is the lowercased
+ * label shown above each figure. Renaming a label renames the query.
+ */
+function statValue(label: string) {
+  return screen.getByLabelText(label).textContent;
+}
+
+function logKill(index: number, time: string) {
+  act(() => {
+    fireEvent.change(screen.getByLabelText(`Kill ${index} time`), {
+      target: { value: time },
+    });
+  });
+}
+
+describe('<MaggotKingSpeedChaser />', () => {
+  beforeEach(() => {
+    render(<MaggotKingSpeedChaser />);
+  });
+
+  it('offers the whole budget at the flat pace before anything is logged', () => {
+    expect(statValue('time used')).toBe('00:00.0');
+    expect(statValue('time left')).toBe('09:00.0');
+    expect(statValue('need per kill')).toBe('01:48.0');
+    expect(statValue('banked')).toBe('+00:00.0');
+  });
+
+  it('re-averages the remaining kills as times are logged', () => {
+    logKill(1, '1:30.0');
+
+    expect(statValue('time used')).toBe('01:30.0');
+    expect(statValue('time left')).toBe('07:30.0');
+    // 750 ticks over four kills is 187.5 each, floored to a whole 187.
+    expect(statValue('need per kill')).toBe('01:52.2');
+    expect(statValue('banked')).toBe('+00:18.0');
+
+    // A slow one: 220 ticks, putting the attempt behind the flat pace.
+    logKill(2, '2:12.0');
+
+    expect(statValue('time used')).toBe('03:42.0');
+    expect(statValue('time left')).toBe('05:18.0');
+    expect(statValue('banked')).toBe('-00:06.0');
+  });
+
+  it('echoes each kill back snapped to the tick it was scored as', () => {
+    // 1:42.5 is not a time the game can produce; 1:42.6 (171 ticks) is.
+    logKill(1, '1:42.5');
+
+    // The same figure also lands in the scoreboard and the verdict.
+    expect(screen.getAllByText('01:42.6').length).toBeGreaterThan(0);
+    expect(screen.getByText('171 ticks')).toBeInTheDocument();
+  });
+
+  it('reports what is left rather than a bare pass/fail', () => {
+    logKill(1, '1:30.0');
+
+    expect(
+      screen.getByRole('status').textContent?.replace(/\s+/g, ' '),
+    ).toContain('07:30.0 left for 4 kills — average 01:52.2 each from here.');
+  });
+
+  it('calls the attempt off once the remaining kills cannot fit', () => {
+    logKill(1, '2:15.0');
+    logKill(2, '2:15.0');
+    logKill(3, '2:15.0');
+    logKill(4, '2:15.0');
+
+    expect(statValue('time left')).toBe('00:00.0');
+    expect(screen.getByRole('status').textContent).toContain('Out of time');
+  });
+
+  it('reports a completed attempt with the time to spare', () => {
+    // 150 ticks each — five of them is 07:30.0, well inside the budget.
+    logKill(1, '1:30.0');
+    logKill(2, '1:30.0');
+    logKill(3, '1:30.0');
+    logKill(4, '1:30.0');
+    logKill(5, '1:30.0');
+
+    expect(statValue('time used')).toBe('07:30.0');
+    expect(statValue('need per kill')).toBe('—');
+    expect(screen.getByRole('status').textContent).toContain('Task complete');
+    expect(screen.getByRole('status').textContent).toContain('01:30.0');
+  });
+
+  it('flags an unreadable time without scoring it', () => {
+    logKill(1, 'oops');
+
+    expect(screen.getByText('Use m:ss.t')).toBeInTheDocument();
+    expect(statValue('time used')).toBe('00:00.0');
+  });
+
+  it('clears the attempt on reset', () => {
+    logKill(1, '1:30.0');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    });
+
+    expect(statValue('time used')).toBe('00:00.0');
+    expect(screen.getByLabelText('Kill 1 time')).toHaveValue('');
+  });
+});

--- a/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.spec.tsx
+++ b/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { MaggotKingSpeedChaser } from './maggot-king-speed-chaser';
 
 /**
@@ -9,11 +9,23 @@ function statValue(label: string) {
   return screen.getByLabelText(label).textContent;
 }
 
-function logKill(index: number, time: string) {
+function killField() {
+  return screen.getByLabelText('Kill time');
+}
+
+/** Types a time into the single entry field without committing it. */
+function type(time: string) {
   act(() => {
-    fireEvent.change(screen.getByLabelText(`Kill ${index} time`), {
-      target: { value: time },
-    });
+    fireEvent.change(killField(), { target: { value: time } });
+  });
+}
+
+/** Types a time and commits it as a split. */
+function logKill(time: string) {
+  type(time);
+
+  act(() => {
+    fireEvent.click(screen.getByRole('button', { name: 'Log kill' }));
   });
 }
 
@@ -29,8 +41,18 @@ describe('<MaggotKingSpeedChaser />', () => {
     expect(statValue('banked')).toBe('+00:00.0');
   });
 
-  it('re-averages the remaining kills as times are logged', () => {
-    logKill(1, '1:30.0');
+  it('asks for one kill at a time and advances as each is committed', () => {
+    expect(screen.getByText('Kill 1 of 5')).toBeInTheDocument();
+
+    logKill('1:30.0');
+
+    expect(screen.getByText('Kill 2 of 5')).toBeInTheDocument();
+    // The field is cleared for the next one rather than holding the last.
+    expect(killField()).toHaveValue('');
+  });
+
+  it('re-averages the remaining kills as splits are committed', () => {
+    logKill('1:30.0');
 
     expect(statValue('time used')).toBe('01:30.0');
     expect(statValue('time left')).toBe('07:30.0');
@@ -39,69 +61,88 @@ describe('<MaggotKingSpeedChaser />', () => {
     expect(statValue('banked')).toBe('+00:18.0');
 
     // A slow one: 220 ticks, putting the attempt behind the flat pace.
-    logKill(2, '2:12.0');
+    logKill('2:12.0');
 
     expect(statValue('time used')).toBe('03:42.0');
     expect(statValue('time left')).toBe('05:18.0');
     expect(statValue('banked')).toBe('-00:06.0');
   });
 
-  it('echoes each kill back snapped to the tick it was scored as', () => {
+  it('previews the tick a time will be scored as before it is committed', () => {
     // 1:42.5 is not a time the game can produce; 1:42.6 (171 ticks) is.
-    logKill(1, '1:42.5');
+    type('1:42.5');
 
-    // The same figure also lands in the scoreboard and the verdict.
-    expect(screen.getAllByText('01:42.6').length).toBeGreaterThan(0);
-    expect(screen.getByText('171 ticks')).toBeInTheDocument();
-  });
-
-  it('reports what is left rather than a bare pass/fail', () => {
-    logKill(1, '1:30.0');
-
-    expect(
-      screen.getByRole('status').textContent?.replace(/\s+/g, ' '),
-    ).toContain('07:30.0 left for 4 kills — average 01:52.2 each from here.');
-  });
-
-  it('calls the attempt off once the remaining kills cannot fit', () => {
-    logKill(1, '2:15.0');
-    logKill(2, '2:15.0');
-    logKill(3, '2:15.0');
-    logKill(4, '2:15.0');
-
-    expect(statValue('time left')).toBe('00:00.0');
-    expect(screen.getByRole('status').textContent).toContain('Out of time');
-  });
-
-  it('reports a completed attempt with the time to spare', () => {
-    // 150 ticks each — five of them is 07:30.0, well inside the budget.
-    logKill(1, '1:30.0');
-    logKill(2, '1:30.0');
-    logKill(3, '1:30.0');
-    logKill(4, '1:30.0');
-    logKill(5, '1:30.0');
-
-    expect(statValue('time used')).toBe('07:30.0');
-    expect(statValue('need per kill')).toBe('—');
-    expect(screen.getByRole('status').textContent).toContain('Task complete');
-    expect(screen.getByRole('status').textContent).toContain('01:30.0');
-  });
-
-  it('flags an unreadable time without scoring it', () => {
-    logKill(1, 'oops');
-
-    expect(screen.getByText('Use m:ss.t')).toBeInTheDocument();
+    expect(screen.getByText('01:42.6')).toBeInTheDocument();
+    expect(screen.getByText(/171 ticks/)).toBeInTheDocument();
+    // Still uncommitted — nothing has been spent.
     expect(statValue('time used')).toBe('00:00.0');
   });
 
-  it('clears the attempt on reset', () => {
-    logKill(1, '1:30.0');
+  it('commits a split that can no longer be edited', () => {
+    logKill('1:36.0');
+
+    // The split is on the board (the same figure is also in the scoreboard,
+    // so this looks inside the splits list specifically)...
+    expect(
+      within(screen.getByRole('list')).getByText('01:36.0'),
+    ).toBeInTheDocument();
+    // ...and the only field on the page is the next kill's, which is empty.
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(killField()).toHaveValue('');
+  });
+
+  it('refuses an unreadable time and spends nothing', () => {
+    logKill('oops');
+
+    expect(screen.getByText('Use m:ss.t')).toBeInTheDocument();
+    expect(statValue('time used')).toBe('00:00.0');
+    expect(screen.getByText('Kill 1 of 5')).toBeInTheDocument();
+  });
+
+  it('closes the entry once five kills are in', () => {
+    // 150 ticks each — five of them is 07:30.0, well inside the budget.
+    logKill('1:30.0');
+    logKill('1:30.0');
+    logKill('1:30.0');
+    logKill('1:30.0');
+    logKill('1:30.0');
+
+    expect(statValue('time used')).toBe('07:30.0');
+    expect(screen.getByRole('status').textContent).toContain('Task complete');
+    expect(screen.queryByLabelText('Kill time')).not.toBeInTheDocument();
+  });
+
+  it('closes the entry once the kills still to come cannot fit', () => {
+    logKill('2:15.0');
+    logKill('2:15.0');
+    logKill('2:15.0');
+    logKill('2:15.0');
+
+    expect(statValue('time left')).toBe('00:00.0');
+    expect(screen.getByRole('status').textContent).toContain('Out of time');
+    expect(screen.queryByLabelText('Kill time')).not.toBeInTheDocument();
+  });
+
+  it('reopens the entry on reset — the only way back out of a committed split', () => {
+    logKill('2:15.0');
+    logKill('2:15.0');
+    logKill('2:15.0');
+    logKill('2:15.0');
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /reset/i }));
     });
 
     expect(statValue('time used')).toBe('00:00.0');
-    expect(screen.getByLabelText('Kill 1 time')).toHaveValue('');
+    expect(screen.getByText('Kill 1 of 5')).toBeInTheDocument();
+    expect(killField()).toHaveValue('');
+  });
+
+  it('leaves reset disabled while there is nothing to reset', () => {
+    expect(screen.getByRole('button', { name: /reset/i })).toBeDisabled();
+
+    logKill('1:30.0');
+
+    expect(screen.getByRole('button', { name: /reset/i })).toBeEnabled();
   });
 });

--- a/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.tsx
+++ b/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.tsx
@@ -15,14 +15,15 @@ import {
 } from './utils/speed-chaser';
 import styles from './maggot-king.module.css';
 
-const emptyAttempt = Array.from<string>({ length: speedChaserKillCount }).fill(
-  '',
-);
-
 /** The flat-pace gridlines on the budget bar: every 1:48.0 short of the end. */
 const paceGridlines = Array.from(
   { length: speedChaserKillCount - 1 },
   (_, index) => (index + 1) * flatPaceTicks,
+);
+
+const killSlots = Array.from(
+  { length: speedChaserKillCount },
+  (_, index) => index,
 );
 
 function plural(count: number, noun: string) {
@@ -39,6 +40,34 @@ function requiredAverageTone(ticks: number | null) {
   }
 
   return ticks < flatPaceTicks ? ('bad' as const) : ('good' as const);
+}
+
+/**
+ * One line under the field, carrying whichever of three things is true: the
+ * parse error, the tick the typed time will be scored as, or how to type one.
+ */
+function EntryHint({
+  error,
+  previewTicks,
+}: {
+  error: string | null;
+  previewTicks: number | null;
+}) {
+  if (error !== null) {
+    return <span className={styles.entryError}>{error}</span>;
+  }
+
+  if (previewTicks !== null) {
+    return (
+      <>
+        Scores as{' '}
+        <span className={styles.entryPreview}>{formatTicks(previewTicks)}</span>{' '}
+        — {plural(previewTicks, 'tick')}
+      </>
+    );
+  }
+
+  return <>As the game writes it: 1:42.60, 1:42.6 or 102.6. Enter to log.</>;
 }
 
 interface StatProps {
@@ -78,7 +107,7 @@ function BudgetBar({
   killTicks,
   summary,
 }: {
-  killTicks: (number | null)[];
+  killTicks: readonly number[];
   summary: SpeedChaserSummary;
 }) {
   // An overrun still has to be visible, so the bar stretches to fit it rather
@@ -101,10 +130,6 @@ function BudgetBar({
       >
         <div className={styles.budgetFill}>
           {killTicks.map((ticks, index) => {
-            if (ticks === null) {
-              return null;
-            }
-
             consumed += ticks;
 
             const isOver = consumed > speedChaserBudgetTicks;
@@ -112,7 +137,8 @@ function BudgetBar({
 
             return (
               <span
-                // Fixed-length list of kill slots — the index is the identity.
+                // Kills are append-only and never reordered, so their position
+                // in the attempt is their identity.
                 key={index}
                 className={`${styles.segment} ${
                   isOver ? styles.segmentOver : ''
@@ -178,7 +204,7 @@ function Verdict({ summary }: { summary: SpeedChaserSummary }) {
     return (
       <p className={`${styles.verdict} ${styles.verdictGood}`} role="status">
         Five kills inside {figure(speedChaserBudgetTicks)}. Split evenly that is{' '}
-        {figure(flatPaceTicks)} each — enter a kill time as it lands and this
+        {figure(flatPaceTicks)} each — log a kill as it lands and this
         re-averages what is left.
       </p>
     );
@@ -205,8 +231,7 @@ function Verdict({ summary }: { summary: SpeedChaserSummary }) {
           <>
             Out of time. {plural(killsLogged, 'kill')} have used{' '}
             {figure(elapsedTicks)} of the {figure(speedChaserBudgetTicks)}, so
-            the {plural(killsRemaining, 'kill')} still to come cannot fit. Reset
-            and go again.
+            the {plural(killsRemaining, 'kill')} still to come cannot fit.
           </>
         )}
       </p>
@@ -238,40 +263,55 @@ function Verdict({ summary }: { summary: SpeedChaserSummary }) {
 /**
  * The Maggot King Speed Chaser planner.
  *
- * The player types each fight duration off the chat message as it lands; every
- * number on the page is derived from those, in ticks, with no timer running.
- * That matters because the achievement counts time in combat, not wall clock —
- * banking special attack energy between kills costs nothing.
+ * One kill is entered at a time and committed as a split — the attempt happened
+ * in an order and cannot be revised mid-flight, so a five-field form was the
+ * wrong shape for it. Correcting a mistake means resetting, which is the same
+ * thing the attempt itself demands.
+ *
+ * Every number is derived from those splits, in ticks, with no timer running:
+ * the achievement counts time in combat, not wall clock, so banking special
+ * attack energy between kills costs nothing.
  */
 export function MaggotKingSpeedChaser() {
-  const [entries, setEntries] = useState<string[]>(emptyAttempt);
+  const [kills, setKills] = useState<number[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
-  const parsed = useMemo(() => entries.map(parseKillTime), [entries]);
-  const killTicks = useMemo(() => parsed.map(({ ticks }) => ticks), [parsed]);
-  const summary = useMemo(() => summariseAttempt(killTicks), [killTicks]);
+  const summary = useMemo(() => summariseAttempt(kills), [kills]);
+  // Parsed as it is typed so the tick it will be scored as is visible before
+  // it is committed, not after.
+  const preview = useMemo(() => parseKillTime(draft), [draft]);
 
-  const isStarted = entries.some((entry) => entry.trim() !== '');
-  const { requiredAverageTicks, killsRemaining, status } = summary;
+  const { requiredAverageTicks, killsLogged, killsRemaining, status } = summary;
   const hasRoomLeft = requiredAverageTicks !== null && requiredAverageTicks > 0;
+  const isAcceptingKills = killsRemaining > 0 && status !== 'failed';
+
+  function reset() {
+    setKills([]);
+    setDraft('');
+    setError(null);
+  }
+
+  function logKill() {
+    const { ticks, error: parseError } = parseKillTime(draft);
+
+    if (ticks === null) {
+      setError(parseError ?? 'Enter the kill time');
+
+      return;
+    }
+
+    setKills((current) => [...current, ticks]);
+    setDraft('');
+    setError(null);
+  }
 
   return (
     <div className={styles.page}>
       <SectionHeader
         title="Maggot King Speed Chaser"
-        subtitle="Five kills, nine minutes. Log each kill and see what the rest have to average."
+        subtitle="Five kills, nine minutes. Log each kill as it lands and see what the rest have to average."
         icon={<StopwatchIcon width={18} height={18} />}
-        actions={
-          <button
-            type="button"
-            className={styles.reset}
-            disabled={!isStarted}
-            onClick={() => {
-              setEntries(emptyAttempt);
-            }}
-          >
-            Reset attempt
-          </button>
-        }
       />
 
       <div className={styles.brief}>
@@ -298,7 +338,7 @@ export function MaggotKingSpeedChaser() {
         <Stat
           label="Time used"
           value={formatTicks(summary.elapsedTicks)}
-          sub={`${summary.killsLogged} of ${speedChaserKillCount} kills logged`}
+          sub={`${killsLogged} of ${speedChaserKillCount} kills logged`}
         />
         <Stat
           label="Time left"
@@ -324,75 +364,108 @@ export function MaggotKingSpeedChaser() {
         />
       </div>
 
-      <BudgetBar killTicks={killTicks} summary={summary} />
+      <BudgetBar killTicks={kills} summary={summary} />
 
       <Verdict summary={summary} />
 
-      <section className={styles.kills}>
-        <div className={styles.killsHead}>
-          <h3 className={styles.killsTitle}>Kill times</h3>
-          <span className={styles.killsHint}>
-            As the game writes them: 1:42.60, 1:42.6 or 102.6
-          </span>
+      {isAcceptingKills ? (
+        <form
+          className={styles.entry}
+          onSubmit={(event) => {
+            event.preventDefault();
+            logKill();
+          }}
+        >
+          <div className={styles.entryHead}>
+            <span className={styles.entryStep}>
+              Kill {killsLogged + 1} of {speedChaserKillCount}
+            </span>
+            {hasRoomLeft && (
+              <span className={styles.entryTarget}>
+                needs {formatTicks(requiredAverageTicks)} or better
+              </span>
+            )}
+          </div>
+          <div className={styles.entryRow}>
+            <input
+              className={`${styles.entryInput} ${
+                error ? styles.entryInputInvalid : ''
+              }`}
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              autoFocus
+              placeholder="1:42.60"
+              aria-label="Kill time"
+              aria-invalid={error !== null}
+              value={draft}
+              onChange={({ target }) => {
+                setDraft(target.value);
+                setError(null);
+              }}
+            />
+            <button type="submit" className={styles.entrySubmit}>
+              Log kill
+            </button>
+          </div>
+          <p className={styles.entryHint} aria-live="polite">
+            <EntryHint error={error} previewTicks={preview.ticks} />
+          </p>
+        </form>
+      ) : (
+        <div className={styles.entry}>
+          <div className={styles.entryHead}>
+            <span className={styles.entryStep}>
+              {killsRemaining === 0 ? 'Attempt finished' : 'Attempt over'}
+            </span>
+          </div>
+          {/* No instruction to "press reset" — the button is immediately
+              below, in the splits header it actually acts on. */}
+          <p className={styles.entryHint}>
+            {killsRemaining === 0
+              ? 'All five kills are in.'
+              : 'There is no time left for the kills still to come.'}
+          </p>
         </div>
-        <ol className={styles.killList}>
-          {entries.map((entry, index) => {
-            const { ticks, error } = parsed[index];
-            const paceDelta = ticks === null ? null : flatPaceTicks - ticks;
+      )}
+
+      <section className={styles.splits}>
+        <div className={styles.splitsHead}>
+          <h3 className={styles.splitsTitle}>Splits</h3>
+          <button
+            type="button"
+            className={styles.reset}
+            disabled={killsLogged === 0}
+            onClick={reset}
+          >
+            Reset attempt
+          </button>
+        </div>
+        <ol className={styles.splitList}>
+          {killSlots.map((slot) => {
+            const ticks = kills[slot];
+
+            if (ticks === undefined) {
+              return (
+                <li key={slot} className={`${styles.split} ${styles.splitGhost}`}>
+                  <span className={styles.splitIndex}>{slot + 1}</span>
+                  <span className={styles.splitTime}>--:--.-</span>
+                </li>
+              );
+            }
+
+            const paceDelta = flatPaceTicks - ticks;
 
             return (
-              <li
-                // Five fixed kill slots — the index is the identity, and rows
-                // are never added, removed or reordered.
-                key={index}
-                className={styles.killRow}
-              >
-                <span className={styles.killIndex}>Kill {index + 1}</span>
-                <input
-                  className={`${styles.killInput} ${
-                    error ? styles.killInputInvalid : ''
-                  }`}
-                  type="text"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder={formatTicks(flatPaceTicks)}
-                  aria-label={`Kill ${index + 1} time`}
-                  aria-invalid={error !== null}
-                  value={entry}
-                  onChange={({ target }) => {
-                    setEntries((current) =>
-                      current.map((value, position) =>
-                        position === index ? target.value : value,
-                      ),
-                    );
-                  }}
-                />
-                <span className={styles.killReadout}>
-                  {error !== null && (
-                    <span className={styles.killError}>{error}</span>
-                  )}
-                  {ticks !== null && (
-                    <>
-                      {/* Echoed back snapped to the tick it was rounded to, so
-                          a time the game could not produce is visibly fixed. */}
-                      <span className={styles.killTicks}>
-                        {formatTicks(ticks)}
-                      </span>
-                      <span>{plural(ticks, 'tick')}</span>
-                      <span
-                        className={
-                          paceDelta !== null && paceDelta < 0
-                            ? styles.killError
-                            : styles.toneGood
-                        }
-                      >
-                        {formatTickDelta(paceDelta ?? 0)} on pace
-                      </span>
-                    </>
-                  )}
-                  {ticks === null && error === null && hasRoomLeft && (
-                    <span>≤ {formatTicks(requiredAverageTicks)} to stay in</span>
-                  )}
+              <li key={slot} className={styles.split}>
+                <span className={styles.splitIndex}>{slot + 1}</span>
+                <span className={styles.splitTime}>{formatTicks(ticks)}</span>
+                <span
+                  className={
+                    paceDelta < 0 ? styles.splitBehind : styles.splitAhead
+                  }
+                >
+                  {formatTickDelta(paceDelta)}
                 </span>
               </li>
             );
@@ -403,10 +476,10 @@ export function MaggotKingSpeedChaser() {
       <p className={styles.footnote}>
         The achievement counts only time spent fighting the boss, so waiting on
         special attack energy or a surge potion cooldown between kills is free —
-        enter each fight duration on its own. Times are held in game ticks
-        (0.6s), which is why anything typed in between snaps to the nearest one.
-        A dead-on {formatTicks(speedChaserBudgetTicks)} counts as inside the
-        limit. Task detail on the{' '}
+        log each fight duration on its own. Times are held in game ticks (0.6s),
+        which is why anything typed in between snaps to the nearest one. A
+        dead-on {formatTicks(speedChaserBudgetTicks)} counts as inside the limit.
+        Task detail on the{' '}
         <a
           href="https://oldschool.runescape.wiki/w/Maggot_King_Speed_Chaser"
           target="_blank"

--- a/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.tsx
+++ b/apps/web/app/tools/maggot-king/maggot-king-speed-chaser.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { StopwatchIcon } from '@radix-ui/react-icons';
+import { SectionHeader } from '@/app/components/section-header';
+import {
+  flatPaceTicks,
+  formatTickDelta,
+  formatTicks,
+  parseKillTime,
+  speedChaserBudgetTicks,
+  speedChaserKillCount,
+  summariseAttempt,
+  type SpeedChaserSummary,
+} from './utils/speed-chaser';
+import styles from './maggot-king.module.css';
+
+const emptyAttempt = Array.from<string>({ length: speedChaserKillCount }).fill(
+  '',
+);
+
+/** The flat-pace gridlines on the budget bar: every 1:48.0 short of the end. */
+const paceGridlines = Array.from(
+  { length: speedChaserKillCount - 1 },
+  (_, index) => (index + 1) * flatPaceTicks,
+);
+
+function plural(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Needing less than the flat pace from here means the time already spent has to
+ * be paid back — that is the point at which the number is worth colouring.
+ */
+function requiredAverageTone(ticks: number | null) {
+  if (ticks === null || ticks <= 0) {
+    return 'idle' as const;
+  }
+
+  return ticks < flatPaceTicks ? ('bad' as const) : ('good' as const);
+}
+
+interface StatProps {
+  label: string;
+  value: string;
+  sub: string;
+  tone?: 'good' | 'bad' | 'idle';
+}
+
+function Stat({ label, value, sub, tone }: StatProps) {
+  const toneClass = {
+    good: styles.toneGood,
+    bad: styles.toneBad,
+    idle: styles.toneIdle,
+  }[tone ?? 'idle'];
+
+  return (
+    <div className={styles.stat}>
+      <span className={styles.statLabel}>{label}</span>
+      <span
+        className={`${styles.statValue} ${tone ? toneClass : ''}`}
+        aria-label={label.toLowerCase()}
+      >
+        {value}
+      </span>
+      <span className={styles.statSub}>{sub}</span>
+    </div>
+  );
+}
+
+/**
+ * The nine minutes drawn to scale, one block per logged kill. Reading the shape
+ * of an attempt — a slow first kill, three tight ones, how much bar is left —
+ * is faster than reading five numbers.
+ */
+function BudgetBar({
+  killTicks,
+  summary,
+}: {
+  killTicks: (number | null)[];
+  summary: SpeedChaserSummary;
+}) {
+  // An overrun still has to be visible, so the bar stretches to fit it rather
+  // than clipping at nine minutes. Once it does, the track no longer *is* the
+  // budget, so the nine-minute line has to be drawn and labelled explicitly —
+  // otherwise the end of the bar reads as the limit it just blew past.
+  const isOverBudget = summary.elapsedTicks > speedChaserBudgetTicks;
+  const scale = Math.max(speedChaserBudgetTicks, summary.elapsedTicks);
+  const budgetOffset = (speedChaserBudgetTicks / scale) * 100;
+  let consumed = 0;
+
+  return (
+    <div className={styles.budget}>
+      <div
+        className={styles.budgetTrack}
+        role="img"
+        aria-label={`${formatTicks(summary.elapsedTicks)} of ${formatTicks(
+          speedChaserBudgetTicks,
+        )} used`}
+      >
+        <div className={styles.budgetFill}>
+          {killTicks.map((ticks, index) => {
+            if (ticks === null) {
+              return null;
+            }
+
+            consumed += ticks;
+
+            const isOver = consumed > speedChaserBudgetTicks;
+            const isAlternate = index % 2 === 1;
+
+            return (
+              <span
+                // Fixed-length list of kill slots — the index is the identity.
+                key={index}
+                className={`${styles.segment} ${
+                  isOver ? styles.segmentOver : ''
+                } ${!isOver && isAlternate ? styles.segmentAlt : ''}`}
+                style={{ width: `${(ticks / scale) * 100}%` }}
+              />
+            );
+          })}
+        </div>
+        {paceGridlines.map((ticks) => (
+          <span
+            key={ticks}
+            className={styles.paceMark}
+            style={{ left: `${(ticks / scale) * 100}%` }}
+          />
+        ))}
+        {isOverBudget && (
+          <span
+            className={styles.budgetMark}
+            style={{ left: `${budgetOffset}%` }}
+          />
+        )}
+      </div>
+      <div className={styles.budgetScale}>
+        <span>00:00.0</span>
+        {isOverBudget && (
+          <span
+            className={styles.budgetScaleLimit}
+            style={{ left: `${budgetOffset}%` }}
+          >
+            {formatTicks(speedChaserBudgetTicks)}
+          </span>
+        )}
+        {/* On a narrow overrun the nine-minute label lands almost on top of the
+            total, and the limit is the one worth reading — the total is already
+            the first stat tile. */}
+        {(!isOverBudget || budgetOffset < 85) && (
+          <span>{formatTicks(scale)}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Verdict({ summary }: { summary: SpeedChaserSummary }) {
+  const {
+    status,
+    killsLogged,
+    killsRemaining,
+    elapsedTicks,
+    remainingTicks,
+    requiredAverageTicks,
+    averageKillTicks,
+    projectedTicks,
+    bankedTicks,
+  } = summary;
+
+  const figure = (ticks: number) => (
+    <span className={styles.verdictFigure}>{formatTicks(ticks)}</span>
+  );
+
+  if (status === 'not-started') {
+    return (
+      <p className={`${styles.verdict} ${styles.verdictGood}`} role="status">
+        Five kills inside {figure(speedChaserBudgetTicks)}. Split evenly that is{' '}
+        {figure(flatPaceTicks)} each — enter a kill time as it lands and this
+        re-averages what is left.
+      </p>
+    );
+  }
+
+  if (status === 'complete') {
+    return (
+      <p className={`${styles.verdict} ${styles.verdictGood}`} role="status">
+        Task complete. Five kills in {figure(elapsedTicks)}, with{' '}
+        {figure(remainingTicks)} to spare.
+      </p>
+    );
+  }
+
+  if (status === 'failed') {
+    return (
+      <p className={`${styles.verdict} ${styles.verdictBad}`} role="status">
+        {killsRemaining === 0 ? (
+          <>
+            Missed it. Five kills took {figure(elapsedTicks)} —{' '}
+            {figure(-remainingTicks)} over the nine minutes.
+          </>
+        ) : (
+          <>
+            Out of time. {plural(killsLogged, 'kill')} have used{' '}
+            {figure(elapsedTicks)} of the {figure(speedChaserBudgetTicks)}, so
+            the {plural(killsRemaining, 'kill')} still to come cannot fit. Reset
+            and go again.
+          </>
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className={`${styles.verdict} ${
+        status === 'at-risk' ? styles.verdictWarn : styles.verdictGood
+      }`}
+      role="status"
+    >
+      {figure(remainingTicks)} left for {plural(killsRemaining, 'kill')} — average{' '}
+      {figure(requiredAverageTicks ?? 0)} each from here.{' '}
+      {bankedTicks >= 0
+        ? `You are ${formatTicks(bankedTicks)} up on the flat pace.`
+        : `You are ${formatTicks(-bankedTicks)} down on the flat pace.`}{' '}
+      {averageKillTicks !== null && projectedTicks !== null && (
+        <>
+          Keep averaging {figure(averageKillTicks)} and the attempt finishes on{' '}
+          {figure(projectedTicks)}.
+        </>
+      )}
+    </p>
+  );
+}
+
+/**
+ * The Maggot King Speed Chaser planner.
+ *
+ * The player types each fight duration off the chat message as it lands; every
+ * number on the page is derived from those, in ticks, with no timer running.
+ * That matters because the achievement counts time in combat, not wall clock —
+ * banking special attack energy between kills costs nothing.
+ */
+export function MaggotKingSpeedChaser() {
+  const [entries, setEntries] = useState<string[]>(emptyAttempt);
+
+  const parsed = useMemo(() => entries.map(parseKillTime), [entries]);
+  const killTicks = useMemo(() => parsed.map(({ ticks }) => ticks), [parsed]);
+  const summary = useMemo(() => summariseAttempt(killTicks), [killTicks]);
+
+  const isStarted = entries.some((entry) => entry.trim() !== '');
+  const { requiredAverageTicks, killsRemaining, status } = summary;
+  const hasRoomLeft = requiredAverageTicks !== null && requiredAverageTicks > 0;
+
+  return (
+    <div className={styles.page}>
+      <SectionHeader
+        title="Maggot King Speed Chaser"
+        subtitle="Five kills, nine minutes. Log each kill and see what the rest have to average."
+        icon={<StopwatchIcon width={18} height={18} />}
+        actions={
+          <button
+            type="button"
+            className={styles.reset}
+            disabled={!isStarted}
+            onClick={() => {
+              setEntries(emptyAttempt);
+            }}
+          >
+            Reset attempt
+          </button>
+        }
+      />
+
+      <div className={styles.brief}>
+        <span className={styles.briefTier}>Grandmaster</span>
+        <span>
+          Budget{' '}
+          <span className={styles.briefValue}>
+            {formatTicks(speedChaserBudgetTicks)}
+          </span>
+        </span>
+        <span>
+          Kills <span className={styles.briefValue}>{speedChaserKillCount}</span>
+        </span>
+        <span>
+          Flat pace{' '}
+          <span className={styles.briefValue}>{formatTicks(flatPaceTicks)}</span>
+        </span>
+        <span>
+          Tick <span className={styles.briefValue}>0.6s</span>
+        </span>
+      </div>
+
+      <div className={styles.stats}>
+        <Stat
+          label="Time used"
+          value={formatTicks(summary.elapsedTicks)}
+          sub={`${summary.killsLogged} of ${speedChaserKillCount} kills logged`}
+        />
+        <Stat
+          label="Time left"
+          value={formatTicks(summary.remainingTicks)}
+          sub={`of ${formatTicks(speedChaserBudgetTicks)}`}
+          tone={status === 'failed' ? 'bad' : 'good'}
+        />
+        <Stat
+          label="Need per kill"
+          value={hasRoomLeft ? formatTicks(requiredAverageTicks) : '—'}
+          sub={
+            killsRemaining === 0
+              ? 'all five kills logged'
+              : `over the last ${plural(killsRemaining, 'kill')}`
+          }
+          tone={requiredAverageTone(requiredAverageTicks)}
+        />
+        <Stat
+          label="Banked"
+          value={formatTickDelta(summary.bankedTicks)}
+          sub={`against ${formatTicks(flatPaceTicks)} a kill`}
+          tone={summary.bankedTicks >= 0 ? 'good' : 'bad'}
+        />
+      </div>
+
+      <BudgetBar killTicks={killTicks} summary={summary} />
+
+      <Verdict summary={summary} />
+
+      <section className={styles.kills}>
+        <div className={styles.killsHead}>
+          <h3 className={styles.killsTitle}>Kill times</h3>
+          <span className={styles.killsHint}>
+            As the game writes them: 1:42.60, 1:42.6 or 102.6
+          </span>
+        </div>
+        <ol className={styles.killList}>
+          {entries.map((entry, index) => {
+            const { ticks, error } = parsed[index];
+            const paceDelta = ticks === null ? null : flatPaceTicks - ticks;
+
+            return (
+              <li
+                // Five fixed kill slots — the index is the identity, and rows
+                // are never added, removed or reordered.
+                key={index}
+                className={styles.killRow}
+              >
+                <span className={styles.killIndex}>Kill {index + 1}</span>
+                <input
+                  className={`${styles.killInput} ${
+                    error ? styles.killInputInvalid : ''
+                  }`}
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder={formatTicks(flatPaceTicks)}
+                  aria-label={`Kill ${index + 1} time`}
+                  aria-invalid={error !== null}
+                  value={entry}
+                  onChange={({ target }) => {
+                    setEntries((current) =>
+                      current.map((value, position) =>
+                        position === index ? target.value : value,
+                      ),
+                    );
+                  }}
+                />
+                <span className={styles.killReadout}>
+                  {error !== null && (
+                    <span className={styles.killError}>{error}</span>
+                  )}
+                  {ticks !== null && (
+                    <>
+                      {/* Echoed back snapped to the tick it was rounded to, so
+                          a time the game could not produce is visibly fixed. */}
+                      <span className={styles.killTicks}>
+                        {formatTicks(ticks)}
+                      </span>
+                      <span>{plural(ticks, 'tick')}</span>
+                      <span
+                        className={
+                          paceDelta !== null && paceDelta < 0
+                            ? styles.killError
+                            : styles.toneGood
+                        }
+                      >
+                        {formatTickDelta(paceDelta ?? 0)} on pace
+                      </span>
+                    </>
+                  )}
+                  {ticks === null && error === null && hasRoomLeft && (
+                    <span>≤ {formatTicks(requiredAverageTicks)} to stay in</span>
+                  )}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      <p className={styles.footnote}>
+        The achievement counts only time spent fighting the boss, so waiting on
+        special attack energy or a surge potion cooldown between kills is free —
+        enter each fight duration on its own. Times are held in game ticks
+        (0.6s), which is why anything typed in between snaps to the nearest one.
+        A dead-on {formatTicks(speedChaserBudgetTicks)} counts as inside the
+        limit. Task detail on the{' '}
+        <a
+          href="https://oldschool.runescape.wiki/w/Maggot_King_Speed_Chaser"
+          target="_blank"
+          rel="noreferrer"
+        >
+          OSRS Wiki
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/tools/maggot-king/maggot-king.module.css
+++ b/apps/web/app/tools/maggot-king/maggot-king.module.css
@@ -1,0 +1,402 @@
+/* ==========================================================================
+   Maggot King Speed Chaser — the clan's first tool page.
+
+   Same language as the rank calculator and the player profile modal: hairline
+   borders and typography instead of card chrome, mono figures in tabular
+   columns, and green reserved for the one thing that matters (time still in
+   hand). Every colour is an --ig-* token; nothing here is a literal.
+   ========================================================================== */
+
+.shell {
+  min-height: 100vh;
+  background: radial-gradient(
+    ellipse at center,
+    rgb(var(--ig-surface-2)) 0%,
+    rgb(var(--ig-bg)) 70%
+  );
+  color: rgb(var(--ig-text));
+}
+
+.page {
+  --mk-hairline: rgb(var(--ig-text-muted) / 0.1);
+  --mk-hairline-strong: rgb(var(--ig-text-muted) / 0.16);
+
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 1.5rem 0.75rem 3rem;
+  }
+}
+
+/* -- the task's fixed numbers, stated once ------------------------------- */
+
+.brief {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.9rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--mk-hairline);
+  border-bottom: 1px solid var(--mk-hairline);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(var(--ig-text-muted));
+}
+
+.briefTier {
+  color: rgb(var(--ig-secondary));
+}
+
+.briefValue {
+  color: rgb(var(--ig-text-light));
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+/* -- scoreboard ----------------------------------------------------------- */
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin: 1.75rem 0 1.25rem;
+  background: var(--mk-hairline);
+  border: 1px solid var(--mk-hairline);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+@media (max-width: 720px) {
+  .stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.9rem 1rem;
+  background: rgb(var(--ig-bg) / 0.55);
+}
+
+.statLabel {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--ig-text-muted));
+}
+
+.statValue {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(1.25rem, 3.4vw, 1.6rem);
+  font-weight: 600;
+  line-height: 1;
+  color: rgb(var(--ig-text));
+}
+
+.statSub {
+  font-size: 11px;
+  line-height: 1.3;
+  color: rgb(var(--ig-text-muted));
+}
+
+.toneGood {
+  color: rgb(var(--ig-secondary));
+}
+
+.toneBad {
+  color: rgb(var(--ig-danger));
+}
+
+.toneIdle {
+  color: rgb(var(--ig-text-muted));
+}
+
+/* -- the nine minutes, drawn ---------------------------------------------- */
+
+.budget {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.budgetTrack {
+  position: relative;
+  height: 34px;
+  border: 1px solid var(--mk-hairline-strong);
+  border-radius: 8px;
+  background: rgb(var(--ig-surface) / 0.5);
+  overflow: hidden;
+}
+
+.budgetFill {
+  display: flex;
+  height: 100%;
+}
+
+/*
+  One block per logged kill, so the shape of the attempt is legible at a
+  glance: where the time went, and how much of the bar is still empty. Kills
+  alternate green/teal purely so two adjacent ones stay distinguishable.
+*/
+.segment {
+  height: 100%;
+  min-width: 2px;
+  background: rgb(var(--ig-secondary) / 0.75);
+  border-right: 1px solid rgb(var(--ig-bg));
+}
+
+.segmentAlt {
+  background: rgb(var(--ig-teal) / 0.6);
+}
+
+.segmentOver {
+  background: rgb(var(--ig-danger) / 0.7);
+}
+
+/* The flat-pace gridlines, at every 1:48.0. Structure, not decoration. */
+.paceMark {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgb(var(--ig-text-muted) / 0.22);
+  pointer-events: none;
+}
+
+/* The nine-minute line, drawn only once the bar has had to stretch past it. */
+.budgetMark {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgb(var(--ig-text) / 0.75);
+  pointer-events: none;
+}
+
+.budgetScale {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: rgb(var(--ig-text-muted));
+}
+
+.budgetScaleLimit {
+  position: absolute;
+  transform: translateX(-50%);
+  color: rgb(var(--ig-text));
+}
+
+/* -- verdict -------------------------------------------------------------- */
+
+.verdict {
+  margin: 1.25rem 0 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--mk-hairline-strong);
+  border-left-width: 2px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: rgb(var(--ig-text-light));
+}
+
+.verdictGood {
+  border-left-color: rgb(var(--ig-secondary));
+}
+
+.verdictWarn {
+  border-left-color: rgb(var(--ig-warning));
+}
+
+.verdictBad {
+  border-left-color: rgb(var(--ig-danger));
+}
+
+.verdictFigure {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: rgb(var(--ig-text));
+}
+
+/* -- kill list ------------------------------------------------------------ */
+
+.kills {
+  margin-top: 2.25rem;
+}
+
+.killsHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--mk-hairline);
+}
+
+.killsTitle {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: rgb(var(--ig-text));
+  margin: 0;
+}
+
+.killsHint {
+  font-size: 11px;
+  color: rgb(var(--ig-text-muted));
+}
+
+.killList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.killRow {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(7rem, 9rem) 1fr;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--mk-hairline);
+}
+
+@media (max-width: 560px) {
+  /* The readout drops to its own line; the field is capped rather than left to
+     fill the row, since nothing typed into it is longer than "01:48.0". */
+  .killRow {
+    grid-template-columns: 4.5rem minmax(0, 12rem);
+  }
+
+  .killReadout {
+    grid-column: 1 / -1;
+  }
+}
+
+.killIndex {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgb(var(--ig-text-muted));
+}
+
+.killInput {
+  width: 100%;
+  height: 34px;
+  padding: 0 0.65rem;
+  border: 1px solid var(--mk-hairline-strong);
+  border-radius: 8px;
+  background: rgb(var(--ig-surface) / 0.6);
+  color: rgb(var(--ig-text));
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.killInput::placeholder {
+  color: rgb(var(--ig-text-muted) / 0.55);
+}
+
+.killInput:hover {
+  border-color: rgb(var(--ig-text-muted) / 0.3);
+}
+
+.killInput:focus {
+  outline: none;
+  border-color: rgb(var(--ig-secondary) / 0.6);
+  background: rgb(var(--ig-surface) / 0.9);
+}
+
+.killInputInvalid,
+.killInputInvalid:focus {
+  border-color: rgb(var(--ig-danger) / 0.7);
+}
+
+.killReadout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.3rem 0.75rem;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: rgb(var(--ig-text-muted));
+}
+
+.killTicks {
+  color: rgb(var(--ig-text-light));
+}
+
+.killError {
+  color: rgb(var(--ig-danger));
+}
+
+/* -- actions / footnote --------------------------------------------------- */
+
+.reset {
+  display: inline-flex;
+  align-items: center;
+  height: 30px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--mk-hairline-strong);
+  border-radius: 8px;
+  background: rgb(var(--ig-surface-2) / 0.5);
+  color: rgb(var(--ig-text-muted));
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.reset:hover:not(:disabled) {
+  color: rgb(var(--ig-text));
+  border-color: rgb(var(--ig-secondary) / 0.4);
+}
+
+.reset:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.reset:focus-visible {
+  outline: 2px solid rgb(var(--ig-secondary) / 0.6);
+  outline-offset: 2px;
+}
+
+.footnote {
+  margin: 2rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--mk-hairline);
+  font-size: 12px;
+  line-height: 1.6;
+  color: rgb(var(--ig-text-muted));
+}
+
+.footnote a {
+  color: rgb(var(--ig-tertiary));
+  text-decoration: none;
+}
+
+.footnote a:hover {
+  text-decoration: underline;
+}

--- a/apps/web/app/tools/maggot-king/maggot-king.module.css
+++ b/apps/web/app/tools/maggot-king/maggot-king.module.css
@@ -232,22 +232,154 @@
   color: rgb(var(--ig-text));
 }
 
-/* -- kill list ------------------------------------------------------------ */
+/* -- entry ----------------------------------------------------------------
+   One kill at a time. The attempt happened in an order and cannot be revised
+   halfway through, so this is a single committing field rather than five
+   editable rows — the page asks for the next kill, and nothing else.
+   ------------------------------------------------------------------------- */
 
-.kills {
-  margin-top: 2.25rem;
+.entry {
+  margin-top: 2rem;
+  padding: 1.1rem 1.25rem 0.9rem;
+  border: 1px solid var(--mk-hairline-strong);
+  border-radius: 12px;
+  background: rgb(var(--ig-surface) / 0.35);
 }
 
-.killsHead {
+.entryHead {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.3rem 1rem;
+  margin-bottom: 0.7rem;
+}
+
+.entryStep {
+  font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: rgb(var(--ig-text));
+}
+
+.entryTarget {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: rgb(var(--ig-text-muted));
+}
+
+.entryRow {
+  display: flex;
+  align-items: stretch;
+  gap: 0.6rem;
+}
+
+/* The one thing on the page you type into, sized to say so. */
+.entryInput {
+  flex: 1;
+  min-width: 0;
+  height: 52px;
+  padding: 0 0.9rem;
+  border: 1px solid var(--mk-hairline-strong);
+  border-radius: 10px;
+  background: rgb(var(--ig-bg) / 0.6);
+  color: rgb(var(--ig-text));
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.entryInput::placeholder {
+  color: rgb(var(--ig-text-muted) / 0.4);
+  font-weight: 500;
+}
+
+.entryInput:hover {
+  border-color: rgb(var(--ig-text-muted) / 0.3);
+}
+
+.entryInput:focus {
+  outline: none;
+  border-color: rgb(var(--ig-secondary) / 0.6);
+  background: rgb(var(--ig-bg) / 0.85);
+}
+
+.entryInputInvalid,
+.entryInputInvalid:focus {
+  border-color: rgb(var(--ig-danger) / 0.7);
+}
+
+.entrySubmit {
+  flex-shrink: 0;
+  padding: 0 1.1rem;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: rgb(var(--ig-secondary));
+  color: rgb(var(--ig-on-accent));
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.entrySubmit:hover {
+  background: color-mix(in srgb, rgb(var(--ig-secondary)) 88%, white);
+}
+
+.entrySubmit:focus-visible {
+  outline: 2px solid rgb(var(--ig-text) / 0.7);
+  outline-offset: 2px;
+}
+
+/* Holds the typing hint, the snapped preview and the parse error in one place,
+   so the block does not change height as they swap. */
+.entryHint {
+  min-height: 1.4em;
+  margin: 0.55rem 0 0;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgb(var(--ig-text-muted));
+}
+
+.entryPreview {
+  color: rgb(var(--ig-secondary));
+  font-weight: 600;
+}
+
+.entryError {
+  color: rgb(var(--ig-danger));
+}
+
+/* -- splits ---------------------------------------------------------------
+   Committed kills, in the order they happened. Five slots always show, so the
+   attempt reads as progress rather than as a list that grows.
+   ------------------------------------------------------------------------- */
+
+.splits {
+  margin-top: 1.75rem;
+}
+
+.splitsHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  padding-bottom: 0.6rem;
+  padding-bottom: 0.7rem;
   border-bottom: 1px solid var(--mk-hairline);
 }
 
-.killsTitle {
+.splitsTitle {
   font-family: var(--font-display), ui-sans-serif, system-ui, sans-serif;
   font-size: 0.95rem;
   font-weight: 600;
@@ -256,98 +388,68 @@
   margin: 0;
 }
 
-.killsHint {
-  font-size: 11px;
-  color: rgb(var(--ig-text-muted));
-}
-
-.killList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.killRow {
+.splitList {
   display: grid;
-  grid-template-columns: 4.5rem minmax(7rem, 9rem) 1fr;
-  align-items: center;
-  gap: 0.75rem 1rem;
-  padding: 0.7rem 0;
-  border-bottom: 1px solid var(--mk-hairline);
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  list-style: none;
+  margin: 0.9rem 0 0;
+  padding: 0;
+  background: var(--mk-hairline);
+  border: 1px solid var(--mk-hairline);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
-@media (max-width: 560px) {
-  /* The readout drops to its own line; the field is capped rather than left to
-     fill the row, since nothing typed into it is longer than "01:48.0". */
-  .killRow {
-    grid-template-columns: 4.5rem minmax(0, 12rem);
-  }
-
-  .killReadout {
-    grid-column: 1 / -1;
+@media (max-width: 640px) {
+  .splitList {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-.killIndex {
-  font-family: var(--font-mono), ui-monospace, monospace;
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgb(var(--ig-text-muted));
-}
-
-.killInput {
-  width: 100%;
-  height: 34px;
-  padding: 0 0.65rem;
-  border: 1px solid var(--mk-hairline-strong);
-  border-radius: 8px;
-  background: rgb(var(--ig-surface) / 0.6);
-  color: rgb(var(--ig-text));
-  font-family: var(--font-mono), ui-monospace, monospace;
-  font-variant-numeric: tabular-nums;
-  font-size: 13px;
-  transition:
-    border-color 0.15s ease,
-    background 0.15s ease;
-}
-
-.killInput::placeholder {
-  color: rgb(var(--ig-text-muted) / 0.55);
-}
-
-.killInput:hover {
-  border-color: rgb(var(--ig-text-muted) / 0.3);
-}
-
-.killInput:focus {
-  outline: none;
-  border-color: rgb(var(--ig-secondary) / 0.6);
-  background: rgb(var(--ig-surface) / 0.9);
-}
-
-.killInputInvalid,
-.killInputInvalid:focus {
-  border-color: rgb(var(--ig-danger) / 0.7);
-}
-
-.killReadout {
+.split {
   display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.3rem 0.75rem;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  background: rgb(var(--ig-bg) / 0.55);
+}
+
+.splitIndex {
   font-family: var(--font-mono), ui-monospace, monospace;
-  font-variant-numeric: tabular-nums;
-  font-size: 12px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
   color: rgb(var(--ig-text-muted));
 }
 
-.killTicks {
-  color: rgb(var(--ig-text-light));
+.splitTime {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1;
+  color: rgb(var(--ig-text));
 }
 
-.killError {
+.splitAhead,
+.splitBehind {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+.splitAhead {
+  color: rgb(var(--ig-secondary));
+}
+
+.splitBehind {
   color: rgb(var(--ig-danger));
+}
+
+/* A kill that has not happened yet: present in the layout, absent in weight. */
+.splitGhost .splitTime {
+  color: rgb(var(--ig-text-muted) / 0.35);
+  font-weight: 500;
 }
 
 /* -- actions / footnote --------------------------------------------------- */

--- a/apps/web/app/tools/maggot-king/page.tsx
+++ b/apps/web/app/tools/maggot-king/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import { NavBar } from '@/app/components/nav-bar';
+import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
+import { MaggotKingSpeedChaser } from './maggot-king-speed-chaser';
+import styles from './maggot-king.module.css';
+
+export const metadata: Metadata = {
+  title: 'Maggot King Speed Chaser | Irons Grotto',
+  description:
+    'Plan the Maggot King Speed Chaser combat achievement: log each kill time and see what the remaining kills have to average to land inside nine minutes.',
+};
+
+/**
+ * Tools are open to anyone — nothing here reads a player record, so there is no
+ * reason to put it behind the Discord gate the calculator needs. Signing in
+ * only changes what the nav bar's Accounts menu has to offer.
+ */
+export default async function MaggotKingToolPage() {
+  const userCalculators = await fetchPlayerAccounts();
+
+  return (
+    <div className={styles.shell}>
+      <NavBar currentPage="tools" userCalculators={userCalculators} />
+      <main>
+        <MaggotKingSpeedChaser />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/tools/maggot-king/utils/speed-chaser.spec.ts
+++ b/apps/web/app/tools/maggot-king/utils/speed-chaser.spec.ts
@@ -1,0 +1,171 @@
+import {
+  flatPaceTicks,
+  formatTickDelta,
+  formatTicks,
+  parseKillTime,
+  speedChaserBudgetTicks,
+  summariseAttempt,
+} from './speed-chaser';
+
+describe('Maggot King Speed Chaser', () => {
+  describe('the budget', () => {
+    it('is 9 minutes expressed in ticks', () => {
+      expect(speedChaserBudgetTicks).toBe((9 * 60) / 0.6);
+      expect(formatTicks(speedChaserBudgetTicks)).toBe('09:00.0');
+    });
+
+    it('splits into a flat pace of 1:48.0 per kill', () => {
+      expect(formatTicks(flatPaceTicks)).toBe('01:48.0');
+    });
+  });
+
+  describe('formatTicks', () => {
+    it.each([
+      [0, '00:00.0'],
+      [1, '00:00.6'],
+      [2, '00:01.2'],
+      [5, '00:03.0'],
+      [100, '01:00.0'],
+      [171, '01:42.6'],
+      [180, '01:48.0'],
+      [900, '09:00.0'],
+    ])('formats %i ticks as %s', (ticks, expected) => {
+      expect(formatTicks(ticks)).toBe(expected);
+    });
+
+    it('signs negative durations', () => {
+      expect(formatTicks(-21)).toBe('-00:12.6');
+    });
+
+    it('always signs a delta, so banked and owed time are told apart', () => {
+      expect(formatTickDelta(21)).toBe('+00:12.6');
+      expect(formatTickDelta(-21)).toBe('-00:12.6');
+      expect(formatTickDelta(0)).toBe('+00:00.0');
+    });
+  });
+
+  describe('parseKillTime', () => {
+    it.each([
+      ['1:42.6', 171],
+      ['1:42.60', 171],
+      ['1:42:6', 171],
+      ['01:42.6', 171],
+      ['102.6', 171],
+      ['1:42', 170],
+      ['102', 170],
+      ['102,6', 171],
+      ['  1:48.0  ', 180],
+    ])('reads %s as %i ticks', (input, expected) => {
+      expect(parseKillTime(input)).toEqual({ ticks: expected, error: null });
+    });
+
+    it('snaps a time the game could not have produced to the nearest tick', () => {
+      // 1:42.5 is not tick-aligned; 171 ticks (1:42.6) is the nearest that is.
+      expect(parseKillTime('1:42.5').ticks).toBe(171);
+      expect(parseKillTime('1:42.2').ticks).toBe(170);
+    });
+
+    it('treats a blank field as a kill that has not happened, not an error', () => {
+      expect(parseKillTime('')).toEqual({ ticks: null, error: null });
+      expect(parseKillTime('   ')).toEqual({ ticks: null, error: null });
+    });
+
+    it.each(['abc', '1:2:3:4', '1:75.0', '0', '0:00.0', '1-42'])(
+      'rejects %s',
+      (input) => {
+        const { ticks, error } = parseKillTime(input);
+
+        expect(ticks).toBeNull();
+        expect(error).toEqual(expect.any(String));
+      },
+    );
+  });
+
+  describe('summariseAttempt', () => {
+    const blank = [null, null, null, null, null];
+
+    it('starts with the whole budget and the flat pace on offer', () => {
+      const summary = summariseAttempt(blank);
+
+      expect(summary).toMatchObject({
+        killsLogged: 0,
+        killsRemaining: 5,
+        elapsedTicks: 0,
+        remainingTicks: 900,
+        requiredAverageTicks: 180,
+        averageKillTicks: null,
+        projectedTicks: null,
+        status: 'not-started',
+      });
+    });
+
+    it('spends the budget and re-averages what is left over the remaining kills', () => {
+      // Two kills at 1:30.0 (150 ticks) leaves 600 ticks over three kills.
+      const summary = summariseAttempt([150, 150, null, null, null]);
+
+      expect(summary.elapsedTicks).toBe(300);
+      expect(summary.remainingTicks).toBe(600);
+      expect(summary.killsRemaining).toBe(3);
+      expect(summary.requiredAverageTicks).toBe(200);
+      expect(formatTicks(summary.requiredAverageTicks!)).toBe('02:00.0');
+    });
+
+    it('floors the required average — a fractional tick is not achievable', () => {
+      // 599 ticks left over three kills is 199.67 each; 199 is the real ceiling.
+      const summary = summariseAttempt([151, 150, null, null, null]);
+
+      expect(summary.remainingTicks).toBe(599);
+      expect(summary.requiredAverageTicks).toBe(199);
+      expect(summary.requiredAverageTicks! * summary.killsRemaining).toBeLessThanOrEqual(
+        summary.remainingTicks,
+      );
+    });
+
+    it('banks time under the flat pace and owes it over', () => {
+      expect(summariseAttempt([150, null, null, null, null]).bankedTicks).toBe(30);
+      expect(summariseAttempt([200, null, null, null, null]).bankedTicks).toBe(-20);
+      expect(summariseAttempt([180, null, null, null, null]).bankedTicks).toBe(0);
+    });
+
+    it('is at risk once the flat pace has been lost, not only once time runs out', () => {
+      expect(summariseAttempt([150, null, null, null, null]).status).toBe(
+        'on-track',
+      );
+      expect(summariseAttempt([200, null, null, null, null]).status).toBe(
+        'at-risk',
+      );
+    });
+
+    it('projects the finish from the pace so far', () => {
+      // Three kills averaging 160 ticks projects 800 for five.
+      expect(summariseAttempt([160, 160, 160, null, null]).projectedTicks).toBe(
+        800,
+      );
+    });
+
+    it('passes a dead-on 09:00.0 — the budget is inclusive', () => {
+      const summary = summariseAttempt([180, 180, 180, 180, 180]);
+
+      expect(summary.elapsedTicks).toBe(900);
+      expect(summary.remainingTicks).toBe(0);
+      expect(summary.status).toBe('complete');
+    });
+
+    it('fails a single tick over', () => {
+      expect(summariseAttempt([180, 180, 180, 180, 181]).status).toBe('failed');
+    });
+
+    it('fails as soon as there is no time left for the kills still to come', () => {
+      // Four kills have consumed the lot; the fifth cannot happen in zero ticks.
+      expect(summariseAttempt([225, 225, 225, 225, null]).status).toBe('failed');
+    });
+
+    it('counts only the kills that were entered, whatever order they arrived in', () => {
+      const summary = summariseAttempt([150, null, 150, null, null]);
+
+      expect(summary.killsLogged).toBe(2);
+      expect(summary.killsRemaining).toBe(3);
+      expect(summary.elapsedTicks).toBe(300);
+    });
+  });
+});

--- a/apps/web/app/tools/maggot-king/utils/speed-chaser.spec.ts
+++ b/apps/web/app/tools/maggot-king/utils/speed-chaser.spec.ts
@@ -82,10 +82,8 @@ describe('Maggot King Speed Chaser', () => {
   });
 
   describe('summariseAttempt', () => {
-    const blank = [null, null, null, null, null];
-
     it('starts with the whole budget and the flat pace on offer', () => {
-      const summary = summariseAttempt(blank);
+      const summary = summariseAttempt([]);
 
       expect(summary).toMatchObject({
         killsLogged: 0,
@@ -101,7 +99,7 @@ describe('Maggot King Speed Chaser', () => {
 
     it('spends the budget and re-averages what is left over the remaining kills', () => {
       // Two kills at 1:30.0 (150 ticks) leaves 600 ticks over three kills.
-      const summary = summariseAttempt([150, 150, null, null, null]);
+      const summary = summariseAttempt([150, 150]);
 
       expect(summary.elapsedTicks).toBe(300);
       expect(summary.remainingTicks).toBe(600);
@@ -112,7 +110,7 @@ describe('Maggot King Speed Chaser', () => {
 
     it('floors the required average — a fractional tick is not achievable', () => {
       // 599 ticks left over three kills is 199.67 each; 199 is the real ceiling.
-      const summary = summariseAttempt([151, 150, null, null, null]);
+      const summary = summariseAttempt([151, 150]);
 
       expect(summary.remainingTicks).toBe(599);
       expect(summary.requiredAverageTicks).toBe(199);
@@ -122,23 +120,23 @@ describe('Maggot King Speed Chaser', () => {
     });
 
     it('banks time under the flat pace and owes it over', () => {
-      expect(summariseAttempt([150, null, null, null, null]).bankedTicks).toBe(30);
-      expect(summariseAttempt([200, null, null, null, null]).bankedTicks).toBe(-20);
-      expect(summariseAttempt([180, null, null, null, null]).bankedTicks).toBe(0);
+      expect(summariseAttempt([150]).bankedTicks).toBe(30);
+      expect(summariseAttempt([200]).bankedTicks).toBe(-20);
+      expect(summariseAttempt([180]).bankedTicks).toBe(0);
     });
 
     it('is at risk once the flat pace has been lost, not only once time runs out', () => {
-      expect(summariseAttempt([150, null, null, null, null]).status).toBe(
+      expect(summariseAttempt([150]).status).toBe(
         'on-track',
       );
-      expect(summariseAttempt([200, null, null, null, null]).status).toBe(
+      expect(summariseAttempt([200]).status).toBe(
         'at-risk',
       );
     });
 
     it('projects the finish from the pace so far', () => {
       // Three kills averaging 160 ticks projects 800 for five.
-      expect(summariseAttempt([160, 160, 160, null, null]).projectedTicks).toBe(
+      expect(summariseAttempt([160, 160, 160]).projectedTicks).toBe(
         800,
       );
     });
@@ -157,11 +155,11 @@ describe('Maggot King Speed Chaser', () => {
 
     it('fails as soon as there is no time left for the kills still to come', () => {
       // Four kills have consumed the lot; the fifth cannot happen in zero ticks.
-      expect(summariseAttempt([225, 225, 225, 225, null]).status).toBe('failed');
+      expect(summariseAttempt([225, 225, 225, 225]).status).toBe('failed');
     });
 
-    it('counts only the kills that were entered, whatever order they arrived in', () => {
-      const summary = summariseAttempt([150, null, 150, null, null]);
+    it('treats a short list as an attempt still in progress', () => {
+      const summary = summariseAttempt([150, 150]);
 
       expect(summary.killsLogged).toBe(2);
       expect(summary.killsRemaining).toBe(3);

--- a/apps/web/app/tools/maggot-king/utils/speed-chaser.ts
+++ b/apps/web/app/tools/maggot-king/utils/speed-chaser.ts
@@ -155,18 +155,18 @@ export interface SpeedChaserSummary {
 }
 
 /**
- * Scores an attempt from the kill times entered so far. Blanks are simply kills
- * that have not happened yet.
+ * Scores an attempt from the kills logged so far, in the order they happened.
+ * Kills are only ever appended, so a short list is simply an attempt in
+ * progress.
  *
  * The budget is inclusive — a dead-on 09:00.0 passes.
  */
 export function summariseAttempt(
-  killTicks: readonly (number | null)[],
+  killTicks: readonly number[],
 ): SpeedChaserSummary {
-  const logged = killTicks.filter((ticks): ticks is number => ticks !== null);
-  const killsLogged = logged.length;
+  const killsLogged = killTicks.length;
   const killsRemaining = Math.max(0, speedChaserKillCount - killsLogged);
-  const elapsedTicks = logged.reduce((total, ticks) => total + ticks, 0);
+  const elapsedTicks = killTicks.reduce((total, ticks) => total + ticks, 0);
   const remainingTicks = speedChaserBudgetTicks - elapsedTicks;
 
   const status = ((): SpeedChaserStatus => {

--- a/apps/web/app/tools/maggot-king/utils/speed-chaser.ts
+++ b/apps/web/app/tools/maggot-king/utils/speed-chaser.ts
@@ -1,0 +1,205 @@
+/**
+ * Maggot King Speed Chaser — the Grandmaster combat achievement.
+ *
+ * "Complete the first 5 kills of the Maggot King within 9 minutes after
+ * entering the arena." Only time spent fighting the boss counts, so what has to
+ * come in under the budget is the sum of the five fight durations, not the wall
+ * clock — which is why this takes kill times rather than a running timer.
+ *
+ * Everything here is integer game ticks. A tick is 600ms, so every duration the
+ * game can produce is a whole number of them; doing the arithmetic in ticks
+ * keeps a five-kill sum exact, where repeatedly adding 0.6 seconds does not.
+ * Ticks are converted to a display string only at the edge, in `formatTicks`.
+ */
+
+/** A game tick, in deciseconds. Ticks are 600ms, so six tenths of a second. */
+export const decisecondsPerTick = 6;
+
+/** 9 minutes: 540 seconds, 900 ticks. */
+export const speedChaserBudgetTicks = 900;
+
+/** The task counts the first five kills of the instance, and only those. */
+export const speedChaserKillCount = 5;
+
+/**
+ * The flat pace: the budget split evenly, 1:48.0 per kill. Not a rule — a kill
+ * may run long and be paid back by a fast one — but it is the line every kill
+ * is measured against, so it is worth naming.
+ */
+export const flatPaceTicks = speedChaserBudgetTicks / speedChaserKillCount;
+
+/** Anything longer than this is a typo, not a kill. */
+const maximumKillTicks = 3000;
+
+export interface ParsedKillTime {
+  /** Ticks, snapped to the nearest whole one. Null when blank or unparseable. */
+  ticks: number | null;
+  /** Set only when the text was present and wrong — a blank field is not an error. */
+  error: string | null;
+}
+
+/**
+ * Formats ticks as `mm:ss.t`.
+ *
+ * The tenths digit is the tick remainder inside the second: a tick is 0.6s, so
+ * the fraction only ever lands on .0/.2/.4/.6/.8. Computed in deciseconds so no
+ * floating point is involved. Minutes are padded to two digits — these numbers
+ * sit in mono columns and have to line up.
+ */
+export function formatTicks(ticks: number): string {
+  const sign = ticks < 0 ? '-' : '';
+  const deciseconds = Math.abs(Math.trunc(ticks)) * decisecondsPerTick;
+  const minutes = Math.floor(deciseconds / 600);
+  const seconds = Math.floor(deciseconds / 10) % 60;
+  const tenths = deciseconds % 10;
+
+  return `${sign}${String(minutes).padStart(2, '0')}:${String(seconds).padStart(
+    2,
+    '0',
+  )}.${tenths}`;
+}
+
+/** Same format, but always signed — for "banked" and per-kill pace deltas. */
+export function formatTickDelta(ticks: number): string {
+  return ticks < 0 ? formatTicks(ticks) : `+${formatTicks(ticks)}`;
+}
+
+/**
+ * Reads a kill time the way a player would type one off the chat message:
+ * `1:42.60`, `1:42.6`, `1:42`, `102.6`, `102`, and `1:42:6` (the third segment
+ * read as the fraction, since that is how the achievement's times are written).
+ *
+ * The result is snapped to the nearest tick, so a time that could not have come
+ * from the game is corrected rather than rejected — and the snapped value is
+ * echoed back so the player sees what was scored.
+ */
+export function parseKillTime(input: string): ParsedKillTime {
+  const trimmed = input.trim().replace(',', '.');
+
+  if (!trimmed) {
+    return { ticks: null, error: null };
+  }
+
+  const segments = trimmed.split(':');
+
+  if (segments.length > 3) {
+    return { ticks: null, error: 'Use m:ss.t' };
+  }
+
+  const [minutesText, secondsText] = ((): [string, string] => {
+    if (segments.length === 3) {
+      return [segments[0], `${segments[1]}.${segments[2]}`];
+    }
+
+    if (segments.length === 2) {
+      return [segments[0], segments[1]];
+    }
+
+    return ['0', segments[0]];
+  })();
+
+  if (!/^\d{1,3}$/.test(minutesText) || !/^\d+(\.\d{1,3})?$/.test(secondsText)) {
+    return { ticks: null, error: 'Use m:ss.t' };
+  }
+
+  const seconds = Number(secondsText);
+
+  if (segments.length > 1 && seconds >= 60) {
+    return { ticks: null, error: 'Seconds must be under 60' };
+  }
+
+  const deciseconds = Math.round((Number(minutesText) * 60 + seconds) * 10);
+  const ticks = Math.round(deciseconds / decisecondsPerTick);
+
+  if (ticks < 1) {
+    return { ticks: null, error: 'A kill takes at least one tick' };
+  }
+
+  if (ticks > maximumKillTicks) {
+    return { ticks: null, error: 'That is longer than the whole attempt' };
+  }
+
+  return { ticks, error: null };
+}
+
+export type SpeedChaserStatus =
+  | 'not-started'
+  | 'on-track'
+  | 'at-risk'
+  | 'failed'
+  | 'complete';
+
+export interface SpeedChaserSummary {
+  killsLogged: number;
+  killsRemaining: number;
+  /** Sum of the logged kills. */
+  elapsedTicks: number;
+  /** Budget minus elapsed. Negative once the attempt has overrun. */
+  remainingTicks: number;
+  /**
+   * The most each remaining kill may take. Floored: a fractional tick is not a
+   * thing the game can give you, so the honest ceiling is the whole tick below.
+   * Null once all five are logged.
+   */
+  requiredAverageTicks: number | null;
+  /** Mean of the kills logged so far. Null before the first one. */
+  averageKillTicks: number | null;
+  /**
+   * Time in hand against the flat 1:48.0 pace. Positive is banked, negative is
+   * owed. This is the number that says whether the attempt is still comfortable.
+   */
+  bankedTicks: number;
+  /** Where the attempt lands if the remaining kills match the average so far. */
+  projectedTicks: number | null;
+  status: SpeedChaserStatus;
+}
+
+/**
+ * Scores an attempt from the kill times entered so far. Blanks are simply kills
+ * that have not happened yet.
+ *
+ * The budget is inclusive — a dead-on 09:00.0 passes.
+ */
+export function summariseAttempt(
+  killTicks: readonly (number | null)[],
+): SpeedChaserSummary {
+  const logged = killTicks.filter((ticks): ticks is number => ticks !== null);
+  const killsLogged = logged.length;
+  const killsRemaining = Math.max(0, speedChaserKillCount - killsLogged);
+  const elapsedTicks = logged.reduce((total, ticks) => total + ticks, 0);
+  const remainingTicks = speedChaserBudgetTicks - elapsedTicks;
+
+  const status = ((): SpeedChaserStatus => {
+    // Over budget, or short of the one tick the next kill would need at minimum.
+    if (remainingTicks < 0 || (killsRemaining > 0 && remainingTicks < 1)) {
+      return 'failed';
+    }
+
+    if (killsLogged === 0) {
+      return 'not-started';
+    }
+
+    if (killsRemaining === 0) {
+      return 'complete';
+    }
+
+    return elapsedTicks > killsLogged * flatPaceTicks ? 'at-risk' : 'on-track';
+  })();
+
+  return {
+    killsLogged,
+    killsRemaining,
+    elapsedTicks,
+    remainingTicks,
+    requiredAverageTicks:
+      killsRemaining > 0 ? Math.floor(remainingTicks / killsRemaining) : null,
+    averageKillTicks:
+      killsLogged > 0 ? Math.round(elapsedTicks / killsLogged) : null,
+    bankedTicks: killsLogged * flatPaceTicks - elapsedTicks,
+    projectedTicks:
+      killsLogged > 0
+        ? elapsedTicks + Math.round((elapsedTicks * killsRemaining) / killsLogged)
+        : null,
+    status,
+  };
+}


### PR DESCRIPTION
<!-- member-summary:start -->
A new Tools menu has its first entry: a planner for the Maggot King Speed Chaser combat achievement. Enter each kill time as it happens and it tells you how much of the nine minutes is left and what the kills still to come have to average.
<!-- member-summary:end -->

## What this is

The site's first tool. `/tools/maggot-king` plans the Grandmaster [Maggot King Speed Chaser](https://oldschool.runescape.wiki/w/Maggot_King_Speed_Chaser) — the first five kills of the instance inside nine minutes.

The useful question mid-attempt isn't "how long has this taken", it's "what do the kills I have left have to average". You type each fight duration as it lands and the page re-derives everything from that.

## How it works

**Everything is integer game ticks.** A tick is 600ms, so every duration the game can produce is a whole number of them. Summing five kills in ticks is exact; repeatedly adding 0.6 seconds is not. Ticks become a display string only at the edge — `formatTicks` goes via deciseconds (`ticks * 6`) to produce `mm:ss.t`, so no floating point is involved anywhere.

- Budget is `900` ticks (9:00.0), flat pace `180` (1:48.0).
- `parseKillTime` reads `1:42.60`, `1:42.6`, `1:42`, `1:42:6`, `102.6` or `102`, and **snaps to the nearest tick** — a time the game couldn't have produced is corrected rather than rejected, and the snapped value is echoed back so the correction is visible.
- The required average is **floored**: a fractional tick isn't achievable, so the honest ceiling is the whole tick below.
- The budget is treated as **inclusive** — a dead-on 09:00.0 passes. See "Not verified" below.

**It takes kill times rather than running a timer**, because the achievement counts only time spent fighting the boss. Holding off on the corpse to bank spec energy or wait out a surge cooldown is free, and a running timer would imply otherwise. The page says so in a footnote.

## Layout

| | |
|---|---|
| `utils/speed-chaser.ts` | all the arithmetic, pure and framework-free |
| `maggot-king-speed-chaser.tsx` + `.module.css` | the page |
| `page.tsx` | the route |
| `app/components/nav-bar.tsx` | a Tools dropdown, plus `currentPage: 'tools'` |

Design follows the player profile modal / rank calculator: `--ig-*` tokens only, hairlines and typography rather than card chrome, mono tabular figures, green as the one accent. Four stat tiles (time used / time left / need per kill / banked against the flat pace), the nine minutes drawn to scale with one block per kill and flat-pace gridlines, a verdict line, then the five kill rows. Empty rows carry the live target (`≤ 01:52.2 to stay in`); logged rows show the snapped time, its tick count and its delta on pace.

**The route is public.** Nothing here reads a player record, so there's no reason to put it behind the Discord gate — `middleware.ts` is untouched. Signing in only changes what the nav's Accounts menu has to offer.

When the bar has to stretch past nine minutes to show an overrun, the nine-minute line is drawn and labelled explicitly — otherwise the end of the track reads as the limit it just blew past.

## Tested

- **47 tests**, all passing: `speed-chaser.spec.ts` (39, the pure math — formatting, parsing, snapping, the floored average, the inclusive boundary, failing a single tick over) and `maggot-king-speed-chaser.spec.tsx` (8, RTL against the tiles' `aria-label`s).
- `yarn check-types` — app project clean. The four `submit-rank-calculator.spec.ts` errors it reports are pre-existing on `main` and untouched by this.
- `npx eslint` clean.
- Rendered in a real browser (headless Chrome against `next dev`) in four states: empty, mid-attempt, over budget, and narrow. Arithmetic spot-checked against the page — 1:36.0 + 2:15.0 + 1:42.6 = 556 ticks, giving used 05:33.6, left 03:26.4, 01:43.2 needed each, banked −00:09.6, projected 09:16.2.

## Not verified

- **The exact-9:00.0 boundary.** "Within 9 minutes" is read as inclusive. That's an assumption about how the game checks it, not something confirmed in-game — it's one constant to flip if it's wrong.
- **Viewports below 500px.** Headless Chrome clamps its window to 500px wide, so the 500px layout was checked but a real phone was not.
- **The nav dropdown was rendered, not clicked** — it mirrors the existing Accounts menu exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvMzr1btfrD1LxkSCLCLf
