### PR TITLE
Point three stale imports at /player so main builds again

### DIFF
--- a/apps/web/app/admin/actions/pick-event-duty-action.ts
+++ b/apps/web/app/admin/actions/pick-event-duty-action.ts
@@ -23,7 +23,7 @@ import { nextClanEventWindow } from '@/app/utils/clan-event-schedule';
 import { selectClanEventPicker } from '@/app/utils/select-clan-event-picker';
 import { pickEventDutyStaff } from '@/app/utils/pick-event-duty-staff';
 import { buildEventDutyMessage } from '@/app/utils/build-event-duty-message';
-import { sendDiscordMessage } from '@/app/rank-calculator/utils/send-discord-message';
+import { sendDiscordMessage } from '@/app/player/utils/send-discord-message';
 import { clanEventDutyChannelId } from '@/config/clan-events';
 import { clientConstants } from '@/config/constants.client';
 

--- a/apps/web/app/admin/utils/announce-clan-event.ts
+++ b/apps/web/app/admin/utils/announce-clan-event.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { sendDiscordMessage } from '@/app/rank-calculator/utils/send-discord-message';
+import { sendDiscordMessage } from '@/app/player/utils/send-discord-message';
 import {
   clanEventAnnouncementChannelId,
   clanEventBotCommand,

--- a/apps/web/app/tools/maggot-king/page.tsx
+++ b/apps/web/app/tools/maggot-king/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { NavBar } from '@/app/components/nav-bar';
-import { fetchPlayerAccounts } from '@/app/rank-calculator/data-sources/fetch-player-accounts';
+import { fetchPlayerAccounts } from '@/app/player/data-sources/fetch-player-accounts';
 import { MaggotKingSpeedChaser } from './maggot-king-speed-chaser';
 import styles from './maggot-king.module.css';
 


### PR DESCRIPTION
<!-- member-summary:start -->
Behind-the-scenes fix so site updates deploy correctly again.
<!-- member-summary:end -->

## `main` does not build

Three files still import from `@/app/rank-calculator/…`, which #100 renamed to `@/app/player/…`. The Vercel build fails with three `Module not found` errors and nothing has deployed since.

```
./apps/web/app/tools/maggot-king/page.tsx:3:1
Module not found: Can't resolve '@/app/rank-calculator/data-sources/fetch-player-accounts'

./apps/web/app/admin/actions/pick-event-duty-action.ts:26:1
./apps/web/app/admin/utils/announce-clan-event.ts:2:1
Module not found: Can't resolve '@/app/rank-calculator/utils/send-discord-message'
```

## Why nothing caught it

All three PRs were cut from a `main` where `app/rank-calculator/` still existed, so each was correct when it was written and each merged without conflict — the rename touched different files than the imports did. Git has no way to see it; only a build does. #100 landed the rename, then #101 and the clan-events work merged on top of it already stale.

## The fix

Both modules exist at their new paths, so this is three import lines:

| file | now imports |
|---|---|
| `app/tools/maggot-king/page.tsx` | `@/app/player/data-sources/fetch-player-accounts` |
| `app/admin/actions/pick-event-duty-action.ts` | `@/app/player/utils/send-discord-message` |
| `app/admin/utils/announce-clan-event.ts` | `@/app/player/utils/send-discord-message` |

No behaviour change — same modules, current paths.

## Tested

- **`yarn build` succeeds**, which is the thing that was failing. All 32 routes generate, `/tools/maggot-king` included.
- `git grep '@/app/rank-calculator'` returns nothing across `apps/web`. The remaining `rank-calculator` references are `@/app/schemas/rank-calculator` and `@/fixtures/rank-calculator/…`, which are real paths and unaffected by the route rename.
- `yarn check-types` clean (bar the four pre-existing `submit-rank-calculator.spec.ts` errors already on `main`).
- `yarn test maggot-king` — 49 passing.

Worth merging promptly: `main` is red until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQvMzr1btfrD1LxkSCLCLf
